### PR TITLE
Update video JSON records

### DIFF
--- a/CCVTAC/CCVTAC.Console/PostProcessing/Tagging/Tagger.cs
+++ b/CCVTAC/CCVTAC.Console/PostProcessing/Tagging/Tagger.cs
@@ -166,7 +166,7 @@ internal static class Tagger
         }
         catch (JsonException ex)
         {
-            return Result.Fail($"Error deserializing JSON from file \"{json}\": {ex.Message}");
+            return Result.Fail($"Error deserializing JSON from file \"{taggingSet.JsonFilePath}\": {ex.Message}");
         }
     }
 

--- a/CCVTAC/CCVTAC.Console/PostProcessing/YouTubeJsonExtensionMethods.cs
+++ b/CCVTAC/CCVTAC.Console/PostProcessing/YouTubeJsonExtensionMethods.cs
@@ -7,9 +7,9 @@ public static class YouTubeJsonExtensionMethods
     /// </summary>
     public static string UploaderSummary(this YouTubeVideoJson.Root data)
     {
-        var uploaderLinkOrId = string.IsNullOrWhiteSpace(data.Uploader_url)
-            ? data.Uploader_id
-            : data.Uploader_url;
+        var uploaderLinkOrId = string.IsNullOrWhiteSpace(data.UploaderUrl)
+            ? data.UploaderId
+            : data.UploaderUrl;
 
         return $"{data.Uploader} ({uploaderLinkOrId})";
     }
@@ -19,7 +19,7 @@ public static class YouTubeJsonExtensionMethods
     /// plain YYYYMMDD version (e.g., "20230827") within the parsed JSON file data.
     /// </summary>
     public static string FormattedUploadDate(this YouTubeVideoJson.Root data) =>
-        $"{data.Upload_date[4..6]}/{data.Upload_date[6..8]}/{data.Upload_date[0..4]}";
+        $"{data.UploadDate[4..6]}/{data.UploadDate[6..8]}/{data.UploadDate[0..4]}";
 
     /// <summary>
     /// Returns a formatted comment using data parsed from the JSON file.
@@ -31,8 +31,8 @@ public static class YouTubeJsonExtensionMethods
         System.Text.StringBuilder sb = new();
         sb.AppendLine("SOURCE DATA:");
         sb.AppendLine($"• Downloaded: {DateTime.Now} using CCVTAC");
-        sb.AppendLine($"• Service: {data.Extractor_key}");
-        sb.AppendLine($"• URL: {data.Webpage_url}");
+        sb.AppendLine($"• Service: {data.ExtractorKey}");
+        sb.AppendLine($"• URL: {data.WebpageUrl}");
         sb.AppendLine($"• Title: {data.Fulltitle}");
         sb.AppendLine($"• Uploader: {data.UploaderSummary()}");
         sb.AppendLine($"• Uploaded: {data.FormattedUploadDate()}");

--- a/CCVTAC/CCVTAC.Console/PostProcessing/YouTubeVideoJson.cs
+++ b/CCVTAC/CCVTAC.Console/PostProcessing/YouTubeVideoJson.cs
@@ -2,86 +2,103 @@ using System.Text.Json.Serialization;
 
 namespace CCVTAC.Console.PostProcessing;
 
+/// <summary>
+/// Represents the data containing the JSON file downloaded alongside the video.
+/// </summary>
+/// <remarks>I recommend using https://json2csharp.com/ for generating this.</remarks>
 public record struct YouTubeVideoJson
 {
     public record struct Root(
         [property: JsonPropertyName("id")] string Id,
         [property: JsonPropertyName("title")] string Title,
-        [property: JsonPropertyName("formats")] IReadOnlyList<FormatData> Formats,
+        [property: JsonPropertyName("formats")] IReadOnlyList<FormatInfo> Formats,
         [property: JsonPropertyName("thumbnails")] IReadOnlyList<Thumbnail> Thumbnails,
         [property: JsonPropertyName("thumbnail")] string Thumbnail,
         [property: JsonPropertyName("description")] string Description,
-        [property: JsonPropertyName("channel_id")] string Channel_id,
-        [property: JsonPropertyName("channel_url")] string Channel_url,
+        [property: JsonPropertyName("channel_id")] string ChannelId,
+        [property: JsonPropertyName("channel_url")] string ChannelUrl,
         [property: JsonPropertyName("duration")] int? Duration,
-        [property: JsonPropertyName("view_count")] int? View_count,
-        [property: JsonPropertyName("age_limit")] int? Age_limit,
-        [property: JsonPropertyName("webpage_url")] string Webpage_url,
+        [property: JsonPropertyName("view_count")] int? ViewCount,
+        [property: JsonPropertyName("age_limit")] int? AgeLimit,
+        [property: JsonPropertyName("webpage_url")] string WebpageUrl,
         [property: JsonPropertyName("categories")] IReadOnlyList<string> Categories,
         [property: JsonPropertyName("tags")] IReadOnlyList<string> Tags,
-        [property: JsonPropertyName("playable_in_embed")] bool? Playable_in_embed,
-        [property: JsonPropertyName("live_status")] string Live_status,
-        [property: JsonPropertyName("automatic_captions")] AutomaticCaptions Automatic_captions,
+        [property: JsonPropertyName("playable_in_embed")] bool? PlayableInEmbed,
+        [property: JsonPropertyName("live_status")] string LiveStatus,
+        [property: JsonPropertyName("automatic_captions")] AutomaticCaptions AutomaticCaptions,
         [property: JsonPropertyName("subtitles")] Subtitles Subtitles,
         [property: JsonPropertyName("heatmap")] IReadOnlyList<Heatmap> Heatmap,
-        [property: JsonPropertyName("like_count")] int? Like_count,
+        [property: JsonPropertyName("comment_count")] int? CommentCount,
+        [property: JsonPropertyName("like_count")] int? LikeCount,
         [property: JsonPropertyName("channel")] string Channel,
-        [property: JsonPropertyName("channel_follower_count")] int? Channel_follower_count,
-        [property: JsonPropertyName("channel_is_verified")] bool? Channel_is_verified,
+        [property: JsonPropertyName("channel_follower_count")] int? ChannelFollowerCount,
+        [property: JsonPropertyName("channel_is_verified")] bool? ChannelIsVerified,
         [property: JsonPropertyName("uploader")] string Uploader,
-        [property: JsonPropertyName("uploader_id")] string Uploader_id,
-        [property: JsonPropertyName("uploader_url")] string Uploader_url,
-        [property: JsonPropertyName("upload_date")] string Upload_date,
+        [property: JsonPropertyName("uploader_id")] string UploaderId,
+        [property: JsonPropertyName("uploader_url")] string UploaderUrl,
+        [property: JsonPropertyName("upload_date")] string UploadDate,
         [property: JsonPropertyName("availability")] string Availability,
-        [property: JsonPropertyName("webpage_url_basename")] string Webpage_url_basename,
-        [property: JsonPropertyName("webpage_url_domain")] string Webpage_url_domain,
+        [property: JsonPropertyName("webpage_url_basename")] string WebpageUrlBasename,
+        [property: JsonPropertyName("webpage_url_domain")] string WebpageUrlDomain,
         [property: JsonPropertyName("extractor")] string Extractor,
-        [property: JsonPropertyName("extractor_key")] string Extractor_key,
-        [property: JsonPropertyName("display_id")] string Display_id,
+        [property: JsonPropertyName("extractor_key")] string ExtractorKey,
+        [property: JsonPropertyName("display_id")] string DisplayId,
         [property: JsonPropertyName("fulltitle")] string Fulltitle,
-        [property: JsonPropertyName("duration_string")] string Duration_string,
-        [property: JsonPropertyName("is_live")] bool? Is_live,
-        [property: JsonPropertyName("was_live")] bool? Was_live,
+        [property: JsonPropertyName("duration_string")] string DurationString,
+        [property: JsonPropertyName("is_live")] bool? IsLive,
+        [property: JsonPropertyName("was_live")] bool? WasLive,
         [property: JsonPropertyName("epoch")] int? Epoch,
         [property: JsonPropertyName("asr")] int? Asr,
         [property: JsonPropertyName("filesize")] int? Filesize,
-        [property: JsonPropertyName("format_id")] string Format_id,
-        [property: JsonPropertyName("format_note")] string Format_note,
-        [property: JsonPropertyName("source_preference")] int? Source_preference,
-        [property: JsonPropertyName("audio_channels")] int? Audio_channels,
+        [property: JsonPropertyName("format_id")] string FormatId,
+        [property: JsonPropertyName("format_note")] string FormatNote,
+        [property: JsonPropertyName("source_preference")] int? SourcePreference,
+        [property: JsonPropertyName("audio_channels")] int? AudioChannels,
         [property: JsonPropertyName("quality")] double? Quality,
-        [property: JsonPropertyName("has_drm")] bool? Has_drm,
+        [property: JsonPropertyName("has_drm")] bool? HasDrm,
         [property: JsonPropertyName("tbr")] double? Tbr,
         [property: JsonPropertyName("url")] string Url,
-        [property: JsonPropertyName("language_preference")] int? Language_preference,
+        [property: JsonPropertyName("language_preference")] int? LanguagePreference,
         [property: JsonPropertyName("ext")] string Ext,
         [property: JsonPropertyName("vcodec")] string Vcodec,
         [property: JsonPropertyName("acodec")] string Acodec,
         [property: JsonPropertyName("container")] string Container,
-        [property: JsonPropertyName("downloader_options")] DownloaderOptions Downloader_options,
+        [property: JsonPropertyName("downloader_options")] DownloaderOptions DownloaderOptions,
         [property: JsonPropertyName("protocol")] string Protocol,
         [property: JsonPropertyName("resolution")] string Resolution,
-        [property: JsonPropertyName("http_headers")] HttpHeaders Http_headers,
-        [property: JsonPropertyName("audio_ext")] string Audio_ext,
-        [property: JsonPropertyName("video_ext")] string Video_ext,
+        [property: JsonPropertyName("http_headers")] HttpHeaders HttpHeaders,
+        [property: JsonPropertyName("audio_ext")] string AudioExt,
+        [property: JsonPropertyName("video_ext")] string VideoExt,
         [property: JsonPropertyName("vbr")] int? Vbr,
         [property: JsonPropertyName("abr")] double? Abr,
         [property: JsonPropertyName("format")] string Format,
-        [property: JsonPropertyName("_type")] string _type,
-        [property: JsonPropertyName("_version")] VersionInfo _version
+        [property: JsonPropertyName("_type")] string Type,
+        [property: JsonPropertyName("_version")] VersionInfo Version
     );
 
     public record struct AutomaticCaptions(
-
+        [property: JsonPropertyName("en")] IReadOnlyList<En> En
     );
 
     public record struct DownloaderOptions(
-        [property: JsonPropertyName("http_chunk_size")] int? http_chunk_size
+        [property: JsonPropertyName("http_chunk_size")] int? HttpChunkSize
     );
 
-    public record struct FormatData(
-        [property: JsonPropertyName("format_id")] string Format_id,
-        [property: JsonPropertyName("format_note")] string Format_note,
+    public record struct En(
+        [property: JsonPropertyName("url")] string Url,
+        [property: JsonPropertyName("ext")] string Ext,
+        [property: JsonPropertyName("protocol")] string Protocol
+    );
+
+    public record struct EnNP72PuUl7o(
+        [property: JsonPropertyName("ext")] string Ext,
+        [property: JsonPropertyName("url")] string Url,
+        [property: JsonPropertyName("name")] string Name
+    );
+
+    public record struct FormatInfo(
+        [property: JsonPropertyName("format_id")] string FormatId,
+        [property: JsonPropertyName("format_note")] string FormatNote,
         [property: JsonPropertyName("ext")] string Ext,
         [property: JsonPropertyName("protocol")] string Protocol,
         [property: JsonPropertyName("acodec")] string Acodec,
@@ -94,32 +111,32 @@ public record struct YouTubeVideoJson
         [property: JsonPropertyName("columns")] int? Columns,
         [property: JsonPropertyName("fragments")] IReadOnlyList<Fragment> Fragments,
         [property: JsonPropertyName("resolution")] string Resolution,
-        [property: JsonPropertyName("aspect_ratio")] double? Aspect_ratio,
-        [property: JsonPropertyName("http_headers")] HttpHeaders Http_headers,
-        [property: JsonPropertyName("audio_ext")] string Audio_ext,
-        [property: JsonPropertyName("video_ext")] string Video_ext,
+        [property: JsonPropertyName("aspect_ratio")] double? AspectRatio,
+        [property: JsonPropertyName("http_headers")] HttpHeaders HttpHeaders,
+        [property: JsonPropertyName("audio_ext")] string AudioExt,
+        [property: JsonPropertyName("video_ext")] string VideoExt,
         [property: JsonPropertyName("vbr")] double? Vbr,
         [property: JsonPropertyName("abr")] double? Abr,
         [property: JsonPropertyName("format")] string Format,
-        [property: JsonPropertyName("manifest_url")] string Manifest_url,
+        [property: JsonPropertyName("manifest_url")] string ManifestUrl,
         [property: JsonPropertyName("quality")] double? Quality,
-        [property: JsonPropertyName("has_drm")] bool? Has_drm,
-        [property: JsonPropertyName("source_preference")] int? Source_preference,
+        [property: JsonPropertyName("has_drm")] object HasDrm,
+        [property: JsonPropertyName("source_preference")] int? SourcePreference,
         [property: JsonPropertyName("asr")] int? Asr,
         [property: JsonPropertyName("filesize")] int? Filesize,
-        [property: JsonPropertyName("audio_channels")] int? Audio_channels,
+        [property: JsonPropertyName("audio_channels")] int? AudioChannels,
         [property: JsonPropertyName("tbr")] double? Tbr,
-        [property: JsonPropertyName("language_preference")] int? Language_preference,
+        [property: JsonPropertyName("language_preference")] int? LanguagePreference,
         [property: JsonPropertyName("container")] string Container,
-        [property: JsonPropertyName("downloader_options")] DownloaderOptions Downloader_options,
+        [property: JsonPropertyName("downloader_options")] DownloaderOptions DownloaderOptions,
         [property: JsonPropertyName("preference")] int? Preference,
-        [property: JsonPropertyName("dynamic_range")] string Dynamic_range,
-        [property: JsonPropertyName("filesize_approx")] int? filesize_approx
+        [property: JsonPropertyName("dynamic_range")] string DynamicRange,
+        [property: JsonPropertyName("filesize_approx")] int? FilesizeApprox
     );
 
     public record struct Fragment(
         [property: JsonPropertyName("url")] string Url,
-        [property: JsonPropertyName("duration")] double? duration
+        [property: JsonPropertyName("duration")] double? Duration
     );
 
     public record struct Heatmap(
@@ -136,7 +153,7 @@ public record struct YouTubeVideoJson
     );
 
     public record struct Subtitles(
-        // TODO: Look into deleting.
+        [property: JsonPropertyName("en-nP7-2PuUl7o")] IReadOnlyList<EnNP72PuUl7o> EnNP72PuUl7o
     );
 
     public record struct Thumbnail(
@@ -145,12 +162,14 @@ public record struct YouTubeVideoJson
         [property: JsonPropertyName("id")] string Id,
         [property: JsonPropertyName("height")] int? Height,
         [property: JsonPropertyName("width")] int? Width,
-        [property: JsonPropertyName("resolution")] string resolution
+        [property: JsonPropertyName("resolution")] string Resolution
     );
 
     public record struct VersionInfo(
         [property: JsonPropertyName("version")] string Version,
-        [property: JsonPropertyName("release_git_head")] string Release_git_head,
-        [property: JsonPropertyName("repository")] string repository
+        [property: JsonPropertyName("release_git_head")] string ReleaseGitHead,
+        [property: JsonPropertyName("repository")] string Repository
     );
+
+
 }

--- a/CCVTAC/CCVTAC.Console/Settings/UserSettings.cs
+++ b/CCVTAC/CCVTAC.Console/Settings/UserSettings.cs
@@ -71,8 +71,9 @@ public sealed class UserSettings
     {
         return
             this.UseUploadYearUploaders?.Contains(videoData.Uploader,
-                                                  StringComparer.OrdinalIgnoreCase) == true &&
-            ushort.TryParse(videoData.Upload_date[0..4], out var parsedYear)
+                                                  StringComparer.OrdinalIgnoreCase) == true
+            &&
+            ushort.TryParse(videoData.UploadDate[0..4], out var parsedYear)
                 ? parsedYear
                 : null;
     }

--- a/TODO.md
+++ b/TODO.md
@@ -4,6 +4,7 @@ Features that I might consider as features or improvements in the future. Not al
 
 - Changing, saving, and reloading of settings while running the program.
 - JSON history that stores more data than just URLs?
+- Save errors to a file with details
 - Lighter logging option
 - Possible to include yt-dlp as a binary? (Even if so, does it make sense to?)
 


### PR DESCRIPTION
I experienced a crash while post-processing a particular URL because there were unexpected properties in the video JSON file.

Summary:
- [X] Add new `YouTubeVideoJson` entries
- [X] Use PascalUse more uniformly
- [X] Fix use of incorrect variable name (leading to printing the JSON instead of the error message...)
- [x] Update TODO file