### PR TITLE
Support only M4A

### DIFF
--- a/CCVTAC/CCVTAC.Console/Help.cs
+++ b/CCVTAC/CCVTAC.Console/Help.cs
@@ -5,8 +5,7 @@ public static class Help
     internal static void Print(Printer printer)
     {
         printer.Print("CodeConscious Video-to-Audio Converter (CCVTAC)");
-        printer.Print("• Easily convert YouTube videos to local audio files with ID3v2 tags!");
-        printer.Print($"  (Supported audio formats: {string.Join(", ", Settings.SettingsService.ValidAudioFormats)})");
+        printer.Print("• Easily convert YouTube videos to local M4A audio files with ID3v2 tags!");
         printer.Print("• Supports video and playlist URLs");
         printer.Print("• Video metadata (uploader name and URL, source URL, etc.) saved to Comment tags");
         printer.Print("• Auto-renames files via specific regex patterns (to remove resource IDs, etc.)");

--- a/CCVTAC/CCVTAC.Console/PostProcessing/Renamer.cs
+++ b/CCVTAC/CCVTAC.Console/PostProcessing/Renamer.cs
@@ -77,9 +77,13 @@ internal static class Renamer
 
         DirectoryInfo dir = new(workingDirectory);
 
-        var audioFilePaths = dir.EnumerateFiles("*")
-                                .Where(f => Settings.SettingsService
-                                                    .ValidAudioFormats.Any(f.Extension.EndsWith));
+        var audioFilePaths = dir.EnumerateFiles("*.m4a");
+        if (!audioFilePaths.Any())
+        {
+            printer.Warning("No audio files to rename were found.");
+            return;
+        }
+
         printer.Print($"Renaming {audioFilePaths.Count()} audio file(s)...");
 
         foreach (FileInfo filePath in audioFilePaths)

--- a/CCVTAC/CCVTAC.Console/Printer.cs
+++ b/CCVTAC/CCVTAC.Console/Printer.cs
@@ -24,6 +24,11 @@ public sealed class Printer
         PrintEmptyLines(appendLines);
     }
 
+    public void Print(Table table)
+    {
+        AnsiConsole.Write(table);
+    }
+
     public void Error(string message, byte appendLines = 0)
     {
         AnsiConsole.MarkupLineInterpolated($"[red]{message}[/]");

--- a/CCVTAC/CCVTAC.Console/Settings/SettingsService.cs
+++ b/CCVTAC/CCVTAC.Console/Settings/SettingsService.cs
@@ -33,25 +33,32 @@ public static class SettingsService
         if (!string.IsNullOrWhiteSpace(header))
             printer.Print(header);
 
-        // const string formatStart = "[bold]";
-        // const string formatEnd = "[/]";
+        var settingPairs = new Dictionary<string, string>()
+        {
+            { $"Audio file format", settings.AudioFormat.ToUpperInvariant() },
+            { $"Split video chapters", settings.SplitChapters ? "ON" : "OFF" },
+            { $"Sleep between batches", $"{settings.SleepSecondsBetweenBatches} second(s)" },
+            { $"Sleep between downloads", $"{settings.SleepSecondsBetweenDownloads} second(s)" },
+            { $"Use-upload-year channels",  $"{settings.UseUploadYearUploaders?.Length.ToString() ?? "no"} channel(s)" },
+            { "Working directory", settings.WorkingDirectory },
+            { "Move-to directory", settings.MoveToDirectory },
+        }.ToImmutableList();
 
         var table = new Table();
         table.Expand();
         table.Border(TableBorder.HeavyEdge);
         table.BorderColor(Color.Grey27);
+
         table.AddColumns("Setting Name", "Setting Value");
+        table.Columns[0].Width = 8; // Not sure what the unit is...
+        table.Columns[1].Width = null;
 
-        table.AddRow($"Audio file format", settings.AudioFormat.ToUpperInvariant());
-        table.AddRow($"Split video chapters", settings.SplitChapters ? "ON" : "OFF");
-        table.AddRow($"Sleep between batches", $"{settings.SleepSecondsBetweenBatches} second(s)");
-        table.AddRow($"Sleep between downloads", $"{settings.SleepSecondsBetweenDownloads} second(s)");
-        table.AddRow($"Use-upload-year channels",
-                     $"{settings.UseUploadYearUploaders?.Length.ToString() ?? "no"} channel(s)");
-        table.AddRow("Working directory", $"{settings.WorkingDirectory}");
-        table.AddRow("Move-to directory", $"{settings.MoveToDirectory}");
+        settingPairs.ForEach(pair =>
+        {
+            table.AddRow(pair.Key, pair.Value);
+        });
 
-        AnsiConsole.Write(table);
+        printer.Print(table);
     }
 
     public static Result<UserSettings> GetUserSettings()

--- a/CCVTAC/CCVTAC.Console/Settings/SettingsService.cs
+++ b/CCVTAC/CCVTAC.Console/Settings/SettingsService.cs
@@ -37,9 +37,18 @@ public static class SettingsService
         {
             { $"Audio file format", settings.AudioFormat.ToUpperInvariant() },
             { $"Split video chapters", settings.SplitChapters ? "ON" : "OFF" },
-            { $"Sleep between batches", $"{settings.SleepSecondsBetweenBatches} second(s)" },
-            { $"Sleep between downloads", $"{settings.SleepSecondsBetweenDownloads} second(s)" },
-            { $"Use-upload-year channels",  $"{settings.UseUploadYearUploaders?.Length.ToString() ?? "no"} channel(s)" },
+            {
+                $"Sleep between batches",
+                $"{settings.SleepSecondsBetweenBatches} {PluralizeIfNeeded("second", settings.SleepSecondsBetweenBatches)}"
+            },
+            {
+                $"Sleep between downloads",
+                $"{settings.SleepSecondsBetweenDownloads} {PluralizeIfNeeded("second", settings.SleepSecondsBetweenDownloads)}"
+            },
+            {
+                $"Use-upload-year channels",
+                $"{settings.UseUploadYearUploaders?.Length.ToString() ?? "no"} {PluralizeIfNeeded("channel", settings.UseUploadYearUploaders?.Length ?? 0)}"
+            },
             { "Working directory", settings.WorkingDirectory },
             { "Move-to directory", settings.MoveToDirectory },
         }.ToImmutableList();
@@ -48,17 +57,25 @@ public static class SettingsService
         table.Expand();
         table.Border(TableBorder.HeavyEdge);
         table.BorderColor(Color.Grey27);
-
         table.AddColumns("Setting Name", "Setting Value");
-        table.Columns[0].Width = 8; // Not sure what the unit is...
-        table.Columns[1].Width = null;
-
         settingPairs.ForEach(pair =>
         {
             table.AddRow(pair.Key, pair.Value);
         });
 
         printer.Print(table);
+
+        static string PluralizeIfNeeded(string term, int count)
+        {
+            return (term, count) switch
+            {
+                { term: "second", count: 1 } => term,
+                { term: "second", count: _ } => "seconds",
+                { term: "channel", count: 1 } => term,
+                { term: "channel", count: _ } => "channels",
+                _ => term
+            };
+        }
     }
 
     public static Result<UserSettings> GetUserSettings()

--- a/CCVTAC/CCVTAC.Console/Settings/SettingsService.cs
+++ b/CCVTAC/CCVTAC.Console/Settings/SettingsService.cs
@@ -9,20 +9,6 @@ public static class SettingsService
     private const string _settingsFileName = "settings.json";
 
     /// <summary>
-    /// A list of audio file format codes used by yt-dlp and that are supported
-    /// by TagLib# (for tagging) as well.
-    /// </summary>
-    public static readonly string[] ValidAudioFormats =
-        new string[] {
-            // "aac", // TODO: Determine if this and other commented formats are worth supporting.
-            // "flac",
-            "m4a", // Recommended for most or all videos since conversation is unnecessary.
-            // "mp3",
-            // "vorbis",
-            // "wav"
-        };
-
-    /// <summary>
     /// Prints a summary of the given settings.
     /// </summary>
     /// <param name="settings"></param>
@@ -157,7 +143,7 @@ public static class SettingsService
                 {
                     WriteIndented = true,
                     Encoder = System.Text.Encodings.Web.JavaScriptEncoder.Create(
-                        System.Text.Unicode.UnicodeRanges.All)
+                                 System.Text.Unicode.UnicodeRanges.All)
                 });
             File.WriteAllText(_settingsFileName, json);
             return Result.Ok();
@@ -185,13 +171,6 @@ public static class SettingsService
             errors.Add($"No working directory was specified in the settings.");
         else if (!Directory.Exists(settings.WorkingDirectory))
             errors.Add($"Working directory \"{settings.WorkingDirectory}\" does not exist.");
-
-        if (!ValidAudioFormats.Contains(settings.AudioFormat))
-        {
-            errors.Add(
-                $"Invalid audio format in settings: \"{settings.AudioFormat}\". " +
-                $"Please use one of the following: \"{string.Join("\", \"", ValidAudioFormats)}\".");
-        }
 
         return errors.Any()
             ? Result.Fail(errors)

--- a/CCVTAC/CCVTAC.Console/Settings/UserSettings.cs
+++ b/CCVTAC/CCVTAC.Console/Settings/UserSettings.cs
@@ -38,7 +38,7 @@ public sealed class UserSettings
     /// The audio file format that should be downloaded. It must be
     /// a format supported by both yt-dlp and TagLib#.
     /// </summary>
-    /// <remarks>I"m only supporting M4A, which requires no conversion, for now.</remarks>
+    /// <remarks>I'm only supporting M4A, which requires no conversion, for now. (See PR #21.)</remarks>
     [JsonPropertyName("audioFormat")]
     public string AudioFormat = "m4a";
 

--- a/CCVTAC/CCVTAC.Console/Settings/UserSettings.cs
+++ b/CCVTAC/CCVTAC.Console/Settings/UserSettings.cs
@@ -38,8 +38,9 @@ public sealed class UserSettings
     /// The audio file format that should be downloaded. It must be
     /// a format supported by both yt-dlp and TagLib#.
     /// </summary>
+    /// <remarks>I"m only supporting M4A, which requires no conversion, for now.</remarks>
     [JsonPropertyName("audioFormat")]
-    public string AudioFormat { get; init; } = "m4a";
+    public string AudioFormat = "m4a";
 
     /// <summary>
     /// How many seconds to sleep between multiple downloads. This value is

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # CCVTAC
 
-CCVTAC (CodeConscious Video-to-Audio Converter) is a small .NET CLI tool that acts as a wrapper around [yt-dlp](https://github.com/yt-dlp/yt-dlp) to enable even easier downloads of audio from specific YouTube videos, playlist, and channels, plus do some automatic post-processing (tagging and moving) as well.
+CCVTAC (CodeConscious Video-to-Audio Converter) is a small .NET CLI tool that acts as a wrapper around [yt-dlp](https://github.com/yt-dlp/yt-dlp) to enable even easier downloads of M4A audio from specific YouTube videos, playlist, and channels, plus do some automatic post-processing (tagging and moving) as well.
 
 Feel free to use it yourself, but please do so responsibly. No warranties or guarantees provided!
 
 ## Features
 
-- Converts YouTube videos to local audio files (mostly thanks to [yt-dlp](https://github.com/yt-dlp/yt-dlp))
+- Converts YouTube videos to local M4A audio files (mostly thanks to [yt-dlp](https://github.com/yt-dlp/yt-dlp))
 - Supports video, playlist, and channel URLs
 - Adds video metadata (uploader name and URL, source URL, etc.) to Comment tags
 - ID3 tags are automatically written where possible


### PR DESCRIPTION
I originally expected to support several audio formats, but M4A appears to be the default for YouTube and doesn't require any conversion, so I'm removing the framework I laid for supporting more formats for now. (YAGNI, indeed.)