### PR TITLE
Refactor working directory file checks

### DIFF
--- a/CCVTAC/CCVTAC.Console/IoUtilties/Directories.cs
+++ b/CCVTAC/CCVTAC.Console/IoUtilties/Directories.cs
@@ -9,18 +9,14 @@ internal static class Directories
     /// </summary>
     /// <param name="workingDirectory"></param>
     /// <param name="customIgnoreFiles">An optional list of files to be excluded.</param>
-    internal static int DirectoryFileCount(
+    internal static ImmutableList<string> GetDirectoryFiles(
         string workingDirectory,
         IEnumerable<string>? customIgnoreFiles = null)
     {
-        HashSet<string> ignoreFiles = new() { ".DS_Store" }; // Ignore macOS system files
+        var ignoreFiles = customIgnoreFiles?.Distinct() ?? Enumerable.Empty<string>();
 
-        if (customIgnoreFiles?.Any() == true)
-        {
-            ignoreFiles.UnionWith(customIgnoreFiles);
-        }
-
-        return Directory.GetFiles(workingDirectory)
-                        .Count(dirFile => !ignoreFiles.Any(ignoreFile => dirFile.EndsWith(ignoreFile)));
+        return Directory.GetFiles(workingDirectory, "*", new EnumerationOptions())
+                        .Where(dirFile => !ignoreFiles.Any(ignoreFile => dirFile.EndsWith(ignoreFile)))
+                        .ToImmutableList();
     }
 }

--- a/CCVTAC/CCVTAC.Console/IoUtilties/Directories.cs
+++ b/CCVTAC/CCVTAC.Console/IoUtilties/Directories.cs
@@ -9,14 +9,13 @@ internal static class Directories
     /// </summary>
     /// <param name="workingDirectory"></param>
     /// <param name="customIgnoreFiles">An optional list of files to be excluded.</param>
-    internal static ImmutableList<string> GetDirectoryFiles(
-        string workingDirectory,
-        IEnumerable<string>? customIgnoreFiles = null)
+    internal static ImmutableList<string> GetDirectoryFiles(string workingDirectory,
+                                                            IEnumerable<string>? customIgnoreFiles = null)
     {
         var ignoreFiles = customIgnoreFiles?.Distinct() ?? Enumerable.Empty<string>();
 
         return Directory.GetFiles(workingDirectory, "*", new EnumerationOptions())
-                        .Where(dirFile => !ignoreFiles.Any(ignoreFile => dirFile.EndsWith(ignoreFile)))
+                        .Where(dirFilePath => !ignoreFiles.Any(ignoreFile => dirFilePath.EndsWith(ignoreFile)))
                         .ToImmutableList();
     }
 }

--- a/CCVTAC/CCVTAC.Console/IoUtilties/Directories.cs
+++ b/CCVTAC/CCVTAC.Console/IoUtilties/Directories.cs
@@ -1,0 +1,26 @@
+using System.IO;
+
+namespace CCVTAC.Console.IoUtilties;
+
+internal static class Directories
+{
+    /// <summary>
+    /// Counts the number of files in the specified directory.
+    /// </summary>
+    /// <param name="workingDirectory"></param>
+    /// <param name="customIgnoreFiles">An optional list of files to be excluded.</param>
+    internal static int DirectoryFileCount(
+        string workingDirectory,
+        IEnumerable<string>? customIgnoreFiles = null)
+    {
+        HashSet<string> ignoreFiles = new() { ".DS_Store" }; // Ignore macOS system files
+
+        if (customIgnoreFiles?.Any() == true)
+        {
+            ignoreFiles.UnionWith(customIgnoreFiles);
+        }
+
+        return Directory.GetFiles(workingDirectory)
+                        .Count(dirFile => !ignoreFiles.Any(ignoreFile => dirFile.EndsWith(ignoreFile)));
+    }
+}

--- a/CCVTAC/CCVTAC.Console/PostProcessing/Mover.cs
+++ b/CCVTAC/CCVTAC.Console/PostProcessing/Mover.cs
@@ -63,25 +63,8 @@ internal static class Mover
         if (failureCount > 0)
             printer.Warning($"However, {failureCount} file(s) could not be moved.");
 
-        WarnAboutOrphanedWorkingFiles(workingDirectory, printer);
-    }
-
-    /// <summary>
-    /// If the working directory contains files when it is expected to be empty,
-    /// then shows a warning message to the user.
-    /// </summary>
-    /// <param name="workingDirectory"></param>
-    /// <param name="printer"></param>
-    private static void WarnAboutOrphanedWorkingFiles(string workingDirectory, Printer printer)
-    {
-        string[] ignoreFiles = new[] { ".DS_Store" }; // Ignore macOS system files
-
-        var files = Directory.GetFiles(workingDirectory)
-                             .Where(dirFile => !ignoreFiles.Any(ignoreFile => dirFile.EndsWith(ignoreFile)));
-
-        if (files.Any())
-        {
-            printer.Warning($"{files.Count()} file(s) unexpectedly remain in the working folder.");
-        }
+        int tempFileCount = IoUtilties.Directories.DirectoryFileCount(workingDirectory);
+        if (tempFileCount > 0)
+            printer.Warning($"{tempFileCount} file(s) unexpectedly remain in the working folder.");
     }
 }

--- a/CCVTAC/CCVTAC.Console/PostProcessing/Mover.cs
+++ b/CCVTAC/CCVTAC.Console/PostProcessing/Mover.cs
@@ -61,10 +61,15 @@ internal static class Mover
 
         printer.Print($"{successCount} file(s) moved in {stopwatch.ElapsedMilliseconds:#,##0}ms.");
         if (failureCount > 0)
+        {
             printer.Warning($"However, {failureCount} file(s) could not be moved.");
+        }
 
-        int tempFileCount = IoUtilties.Directories.DirectoryFileCount(workingDirectory);
-        if (tempFileCount > 0)
-            printer.Warning($"{tempFileCount} file(s) unexpectedly remain in the working folder.");
+        var tempFiles = IoUtilties.Directories.GetDirectoryFiles(workingDirectory);
+        if (tempFiles.Any())
+        {
+            printer.Warning($"{tempFiles.Count} file(s) unexpectedly remain in the working folder:");
+            tempFiles.ForEach(file => printer.Print($"• {file}"));
+        }
     }
 }

--- a/CCVTAC/CCVTAC.Console/PostProcessing/Renamer.cs
+++ b/CCVTAC/CCVTAC.Console/PostProcessing/Renamer.cs
@@ -7,11 +7,12 @@ namespace CCVTAC.Console.PostProcessing;
 
 internal static class Renamer
 {
-    private record struct RenamePattern(Regex Regex, string ReplaceWithPattern, string Description);
+    private record struct RenamePattern(Regex Regex, string ReplaceWithPattern, string? Description = null);
 
     // TODO: Convert this into a setting.
     private static readonly IReadOnlyList<RenamePattern> RenamePatterns = new List<RenamePattern>()
     {
+        // Universal, to always be run first.
         new(
             new Regex(@"\s\[[\w_-]{11}\](?=\.\w{3,5})"),
             string.Empty,
@@ -20,6 +21,7 @@ internal static class Renamer
             new Regex(@"\s{2,}"),
             " ",
             "Remove extra spaces"),
+        // Various patterns
         new(
             new Regex(@"(?<= - )\d{3} (\d{1,3})\.?\s?"),
             "%<1>s - ",
@@ -60,6 +62,15 @@ internal static class Renamer
             new Regex(@"^(.+?)(?: - [｢「『【])(.+)(?:[」｣』】]).*(?=（Full Ver.）)"),
             "%<1>s - %<2>s",
             "Reformat 'ARTIST - \'TITLE\' ]'"),
+        new(
+            new Regex(@"(\d+) - \[(feat.+)\] (.+) ⧸ (.+)(?=\.\w{3,4})"),
+            "%<4>s - %<4>s - %<1>s - %<3>s (%<2>s)"
+        ),
+        new(
+            new Regex(@"(.+) ?⧸ ?(.+)(?= ：(?: \w+)?\.\w{3,4})"),
+            "%<2>s - %<1>s"
+        ),
+        // Cleanup:
         new(
             new Regex(@" - - "),
             " - ",

--- a/CCVTAC/CCVTAC.Console/PostProcessing/Tagging/DetectionSchemeBank.cs
+++ b/CCVTAC/CCVTAC.Console/PostProcessing/Tagging/DetectionSchemeBank.cs
@@ -36,6 +36,11 @@ internal static class DetectionSchemeBank
             MatchGroupId.Second,
             SourceMetadataField.Title
         ),
+        new(
+            """(.+) ?⧸ ?(.+)(?= ：(?: \w+)?\.\w{3,4})""", // TITLE ⧸ ARTIST ：
+            MatchGroupId.First,
+            SourceMetadataField.Title
+        ),
     };
 
     internal static IReadOnlyList<DetectionScheme> Artist = new List<DetectionScheme>()
@@ -65,6 +70,11 @@ internal static class DetectionSchemeBank
         new(
             """^(.+?)「(.+)」""", // ARTIST「TITLE」 on one line
             MatchGroupId.First,
+            SourceMetadataField.Title
+        ),
+        new(
+            """(.+) ?⧸ ?(.+)(?= ：(?: \w+)?\.\w{3,4})""", // TITLE ⧸ ARTIST ：
+            MatchGroupId.Second,
             SourceMetadataField.Title
         ),
     };

--- a/CCVTAC/CCVTAC.Console/PostProcessing/Tagging/DetectionSchemeBank.cs
+++ b/CCVTAC/CCVTAC.Console/PostProcessing/Tagging/DetectionSchemeBank.cs
@@ -99,6 +99,11 @@ internal static class DetectionSchemeBank
             "pseudo-Topic style"
         ),
         new (
+            """(?<=アルバム[『「]).+(?=[」』])""", // アルバム「NAME」
+            MatchGroupId.Zero,
+            SourceMetadataField.Title
+        ),
+        new (
             """(?<='s ['"]).+(?=['"] album)""",
             MatchGroupId.Zero,
             SourceMetadataField.Description
@@ -174,6 +179,11 @@ internal static class DetectionSchemeBank
             """(?<=\(C\)\s|\(C\))[12]\d{3}""", // (C) 2000
             MatchGroupId.Zero,
             SourceMetadataField.Description
+        ),
+        new (
+            """^(.+?)「(.+)」\s?([12]\d{3})\s?""", // ARTIST「TITLE」YEAR
+            MatchGroupId.Third,
+            SourceMetadataField.Title
         )
     };
 }

--- a/CCVTAC/CCVTAC.Console/Program.cs
+++ b/CCVTAC/CCVTAC.Console/Program.cs
@@ -65,10 +65,12 @@ internal static class Program
         UserSettings userSettings = settingsResult.Value;
         SettingsService.PrintSummary(userSettings, printer, "Settings loaded OK.");
 
-        var tempFileCount = IoUtilties.Directories.DirectoryFileCount(userSettings.WorkingDirectory);
-        if (tempFileCount > 0)
+        // The working directory should be empty.
+        var tempFiles = IoUtilties.Directories.GetDirectoryFiles(userSettings.WorkingDirectory);
+        if (tempFiles.Any())
         {
-            printer.Error($"{tempFileCount} file(s) unexpectedly found in the working directory, so will abort.");
+            printer.Error($"{tempFiles.Count} file(s) unexpectedly found in the working directory, so will abort:");
+            tempFiles.ForEach(file => printer.Print($"• {file}"));
             return;
         }
 

--- a/CCVTAC/CCVTAC.Console/Program.cs
+++ b/CCVTAC/CCVTAC.Console/Program.cs
@@ -65,13 +65,10 @@ internal static class Program
         UserSettings userSettings = settingsResult.Value;
         SettingsService.PrintSummary(userSettings, printer, "Settings loaded OK.");
 
-        // TODO: Refactor with the similar code below and elsewhere.
-        string[] ignoreFiles = new[] { ".DS_Store" }; // Ignore macOS system files
-        if (Directory.GetFiles(userSettings.WorkingDirectory)
-                     .Where(dirFile => !ignoreFiles.Any(file => dirFile.EndsWith(file)))
-                     .Any())
+        var tempFileCount = IoUtilties.Directories.DirectoryFileCount(userSettings.WorkingDirectory);
+        if (tempFileCount > 0)
         {
-            printer.Error("There are unexpectedly files in the working directory, so will abort.");
+            printer.Error($"{tempFileCount} file(s) unexpectedly found in the working directory, so will abort.");
             return;
         }
 

--- a/TODO.md
+++ b/TODO.md
@@ -8,9 +8,9 @@ Features that I might consider as features or improvements in the future. Not al
 - Stop downloading if there are repeated errors from yt-dlp
 - Logging levels (current/full vs. light)
 - Logging to a file
+- JSON history that stores more data than just URLs (Or maybe the log file would be sufficient? If so, is the history file even needed? Maybe allow up-and-down scrolling through history?)
 - yt-dlp can handle tabs on YouTube channels too, so look into supporting those
 - Changing, saving, and reloading of settings while running the program
-- JSON history that stores more data than just URLs?
 - Save errors to a file with details
 - Possible to include yt-dlp as a binary? (Even if so, does it make sense to?)
 - Count generated files for final output


### PR DESCRIPTION
- DRY up the checks for files in the working directory when there should be none
- No need to specify `.DS_Store` as a file to ignore anymore