### PR TITLE
Add "ignore upload year" to settings

### DIFF
--- a/CCVTAC/CCVTAC.Console/PostProcessing/Tagging/TagDetector.cs
+++ b/CCVTAC/CCVTAC.Console/PostProcessing/Tagging/TagDetector.cs
@@ -30,10 +30,10 @@ internal class TagDetector
 
     internal ushort? DetectReleaseYear(VideoMetadata videoData, ushort? defaultYear)
     {
-        ushort output = Detectors.DetectSingle<ushort>(videoData, DetectionSchemeBank.Year, default);
+        ushort detectedYear = Detectors.DetectSingle<ushort>(videoData, DetectionSchemeBank.Year, default);
 
-        return output is default(ushort) // The default ushort value indicates no match was found.
+        return detectedYear is default(ushort) // The default ushort value indicates no match was found.
             ? defaultYear
-            : output;
+            : detectedYear;
     }
 }

--- a/CCVTAC/CCVTAC.Console/PostProcessing/Tagging/TagDetector.cs
+++ b/CCVTAC/CCVTAC.Console/PostProcessing/Tagging/TagDetector.cs
@@ -28,7 +28,7 @@ internal class TagDetector
         return Detectors.DetectMultiple<string>(videoData, DetectionSchemeBank.Composers, null, "; ");
     }
 
-    internal ushort? DetectReleaseYear(VideoMetadata videoData, ushort? defaultYear = null)
+    internal ushort? DetectReleaseYear(VideoMetadata videoData, ushort? defaultYear)
     {
         ushort output = Detectors.DetectSingle<ushort>(videoData, DetectionSchemeBank.Year, default);
 

--- a/CCVTAC/CCVTAC.Console/PostProcessing/Tagging/Tagger.cs
+++ b/CCVTAC/CCVTAC.Console/PostProcessing/Tagging/Tagger.cs
@@ -149,13 +149,13 @@ internal static class Tagger
             }
             else
             {
-                ushort? defaultYear = userSettings.GetVideoUploadDateIfRegisteredUploader(videoData);
-                if (defaultYear is not null)
+                ushort? maybeDefaultYear = userSettings.GetAppropriateReleaseDateIfAny(videoData);
+                if (maybeDefaultYear is not null)
                 {
-                    printer.Print($"Will use upload year {defaultYear} for uploader \"{videoData.Uploader}\" if no other year is detected.");
+                    printer.Print($"Will use video upload year \"{maybeDefaultYear}\" by default no other is detected.");
                 }
 
-                if (tagDetector.DetectReleaseYear(videoData, defaultYear) is ushort year)
+                if (tagDetector.DetectReleaseYear(videoData, maybeDefaultYear) is ushort year)
                 {
                     printer.Print($"• Found year \"{year}\"");
                     taggedFile.Tag.Year = year;

--- a/CCVTAC/CCVTAC.Console/PostProcessing/Tagging/Tagger.cs
+++ b/CCVTAC/CCVTAC.Console/PostProcessing/Tagging/Tagger.cs
@@ -150,10 +150,6 @@ internal static class Tagger
             else
             {
                 ushort? maybeDefaultYear = userSettings.GetAppropriateReleaseDateIfAny(videoData);
-                if (maybeDefaultYear is not null)
-                {
-                    printer.Print($"Will use video upload year \"{maybeDefaultYear}\" by default no other is detected.");
-                }
 
                 if (tagDetector.DetectReleaseYear(videoData, maybeDefaultYear) is ushort year)
                 {

--- a/CCVTAC/CCVTAC.Console/Settings/SettingsService.cs
+++ b/CCVTAC/CCVTAC.Console/Settings/SettingsService.cs
@@ -32,8 +32,8 @@ public static class SettingsService
                 $"{settings.SleepSecondsBetweenDownloads} {PluralizeIfNeeded("second", settings.SleepSecondsBetweenDownloads)}"
             },
             {
-                $"Use-upload-year channels",
-                $"{settings.UseUploadYearUploaders?.Length.ToString() ?? "no"} {PluralizeIfNeeded("channel", settings.UseUploadYearUploaders?.Length ?? 0)}"
+                $"Ignore-upload-year channels",
+                $"{settings.IgnoreUploadYearUploaders?.Length.ToString() ?? "no"} {PluralizeIfNeeded("channel", settings.IgnoreUploadYearUploaders?.Length ?? 0)}"
             },
             { "Working directory", settings.WorkingDirectory },
             { "Move-to directory", settings.MoveToDirectory },

--- a/CCVTAC/CCVTAC.Console/Settings/UserSettings.cs
+++ b/CCVTAC/CCVTAC.Console/Settings/UserSettings.cs
@@ -58,24 +58,25 @@ public sealed class UserSettings
 
     /// <summary>
     /// A list of uploader names for whom the video upload dates' year value
-    /// can be used at the video's release year. It should contain channel names.
-    /// Case can be ignored.
+    /// should not be used at the video's release year. It should contain channel names.
     /// </summary>
-    [JsonPropertyName("useUploadYearUploaders")]
-    public string[]? UseUploadYearUploaders { get; init; }
+    [JsonPropertyName("ignoreUploadYearUploaders")]
+    public string[]? IgnoreUploadYearUploaders { get; init; }
 
     /// <summary>
     /// If the supplied video uploader is specified in the settings, returns the video's upload year.
     /// Otherwise, returns null.
     /// </summary>
-    public ushort? GetVideoUploadDateIfRegisteredUploader(VideoMetadata videoData)
+    public ushort? GetAppropriateReleaseDateIfAny(VideoMetadata videoData)
     {
-        return
-            this.UseUploadYearUploaders?.Contains(videoData.Uploader,
-                                                  StringComparer.OrdinalIgnoreCase) == true
-            &&
-            ushort.TryParse(videoData.UploadDate[0..4], out ushort parsedYear)
-                ? parsedYear
-                : null;
+        if (this.IgnoreUploadYearUploaders?.Contains(videoData.Uploader,
+                                                     StringComparer.OrdinalIgnoreCase) == true)
+        {
+            return null;
+        }
+
+        return ushort.TryParse(videoData.UploadDate[0..4], out ushort parsedYear)
+            ? parsedYear
+            : null;
     }
 }


### PR DESCRIPTION
This PR essentially reverse one of the settings: Instead of manually adding channel names whose video upload dates should be ignored, the upload date will always be used by default except for specific channel names that should be excluded.

In other words, using the upload date as the release year is now opt-out instead of opt-in.

I expect this will result in shorter settings files and less need to add new channel names. (I know it immediately did for me.)