### PR TITLE
Refactor external app error codes

### DIFF
--- a/CCVTAC/CCVTAC.Console/Downloading/Downloader.cs
+++ b/CCVTAC/CCVTAC.Console/Downloading/Downloader.cs
@@ -41,7 +41,17 @@ internal static class Downloader
             userSettings.WorkingDirectory!
         );
 
-        Result<int> downloadResult = Runner.Run(downloadToolSettings, printer);
+        // Source of error codes: https://github.com/yt-dlp/yt-dlp/issues/4262#issuecomment-1173133105
+        Dictionary<int, string> ytdlpExitCodes = new()
+        {
+            { 0, "Success" },
+            { 1, "Unspecific error" },
+            { 2, "Error in provided options" },
+            { 100, "yt-dlp must restart for update to complete" },
+            { 101, "Download cancelled by --max-downloads, etc." },
+        };
+
+        Result downloadResult = Runner.Run(downloadToolSettings, printer, ytdlpExitCodes);
 
         if (downloadResult.IsFailed)
         {
@@ -105,6 +115,11 @@ internal static class Downloader
         if (settings.SplitChapters && downloadType == DownloadType.Media)
         {
             args.Add("--split-chapters");
+        }
+
+        if (settings.VerboseDownloaderOutput)
+        {
+            args.Add("--verbose");
         }
 
         // TODO: Consider moving this logic to the individual types, via the interface.

--- a/CCVTAC/CCVTAC.Console/Downloading/Downloader.cs
+++ b/CCVTAC/CCVTAC.Console/Downloading/Downloader.cs
@@ -35,14 +35,8 @@ internal static class Downloader
             downloadEntity.VideoDownloadType,
             downloadEntity.PrimaryResource.FullResourceUrl);
 
-        UtilitySettings downloadToolSettings = new(
-            ExternalProgram,
-            args,
-            userSettings.WorkingDirectory!
-        );
-
         // Source of error codes: https://github.com/yt-dlp/yt-dlp/issues/4262#issuecomment-1173133105
-        Dictionary<int, string> ytdlpExitCodes = new()
+        Dictionary<int, string> downloaderExitCodes = new()
         {
             { 0, "Success" },
             { 1, "Unspecific error" },
@@ -51,7 +45,14 @@ internal static class Downloader
             { 101, "Download cancelled by --max-downloads, etc." },
         };
 
-        Result downloadResult = Runner.Run(downloadToolSettings, printer, ytdlpExitCodes);
+        UtilitySettings downloadToolSettings = new(
+            ExternalProgram,
+            args,
+            userSettings.WorkingDirectory!,
+            downloaderExitCodes
+        );
+
+        Result downloadResult = Runner.Run(downloadToolSettings, printer);
 
         if (downloadResult.IsFailed)
         {
@@ -74,6 +75,7 @@ internal static class Downloader
                 ExternalProgram,
                 supplementaryArgs,
                 userSettings.WorkingDirectory!,
+                downloaderExitCodes,
                 false
             );
 

--- a/CCVTAC/CCVTAC.Console/ExternalUtilities/Runner.cs
+++ b/CCVTAC/CCVTAC.Console/ExternalUtilities/Runner.cs
@@ -62,9 +62,9 @@ internal static class Runner
         if (knownExitCodes is not null &&
             knownExitCodes.ContainsKey(exitCode))
         {
-            return Result.Fail($"External program \"{settings.Program.Name}\" reported error #{exitCode}: {knownExitCodes[exitCode]}.");
+            return Result.Fail($"External program \"{settings.Program.Name}\" reported error {exitCode}: {knownExitCodes[exitCode]}.");
         }
 
-        return Result.Fail($"External program \"{settings.Program.Name}\" reported an error (#{exitCode}).");
+        return Result.Fail($"External program \"{settings.Program.Name}\" reported an error ({exitCode}).");
     }
 }

--- a/CCVTAC/CCVTAC.Console/ExternalUtilities/Runner.cs
+++ b/CCVTAC/CCVTAC.Console/ExternalUtilities/Runner.cs
@@ -5,9 +5,7 @@ namespace CCVTAC.Console.ExternalUtilities;
 
 internal static class Runner
 {
-    internal static Result Run(UtilitySettings settings,
-                               Printer printer,
-                               IDictionary<int, string>? knownExitCodes = null)
+    internal static Result Run(UtilitySettings settings, Printer printer)
     {
         Stopwatch stopwatch = new();
         stopwatch.Start();
@@ -59,10 +57,10 @@ internal static class Runner
             return Result.Ok();
         }
 
-        if (knownExitCodes is not null &&
-            knownExitCodes.ContainsKey(exitCode))
+        if (settings.ExitCodes is not null &&
+            settings.ExitCodes.ContainsKey(exitCode))
         {
-            return Result.Fail($"External program \"{settings.Program.Name}\" reported error {exitCode}: {knownExitCodes[exitCode]}.");
+            return Result.Fail($"External program \"{settings.Program.Name}\" reported error {exitCode}: {settings.ExitCodes[exitCode]}.");
         }
 
         return Result.Fail($"External program \"{settings.Program.Name}\" reported an error ({exitCode}).");

--- a/CCVTAC/CCVTAC.Console/ExternalUtilities/UtilitySettings.cs
+++ b/CCVTAC/CCVTAC.Console/ExternalUtilities/UtilitySettings.cs
@@ -10,5 +10,6 @@ internal sealed record UtilitySettings(
     ExternalProgram Program,
     string Args,
     string WorkingDirectory,
+    Dictionary<int, string>? ExitCodes = null,
     bool RedirectStandardOutput = false
 );

--- a/CCVTAC/CCVTAC.Console/PostProcessing/PostProcessing.cs
+++ b/CCVTAC/CCVTAC.Console/PostProcessing/PostProcessing.cs
@@ -61,7 +61,7 @@ public sealed class Setup(UserSettings userSettings, Printer printer)
 
     internal Result<CollectionMetadata> GetCollectionJson(string workingDirectory)
     {
-        Regex regex = new("""(?<=\[)[\w\-]{20,}(?=\]\.info.json)"""); // Assumes ID length is >= 20 chars.
+        Regex regex = new("""(?<=\[)[\w\-]{17,}(?=\]\.info.json)"""); // Assumes a minimum ID length.
 
         try
         {

--- a/CCVTAC/CCVTAC.Console/Settings/UserSettings.cs
+++ b/CCVTAC/CCVTAC.Console/Settings/UserSettings.cs
@@ -64,6 +64,12 @@ public sealed class UserSettings
     public string[]? IgnoreUploadYearUploaders { get; init; }
 
     /// <summary>
+    /// Shows verbose output from the external downloader tool if true; otherwise, shows normal output.
+    /// </summary>
+    [JsonPropertyName("verboseDownloaderOutput")]
+    public bool VerboseDownloaderOutput { get; init; } = false;
+
+    /// <summary>
     /// If the supplied video uploader is specified in the settings, returns the video's upload year.
     /// Otherwise, returns null.
     /// </summary>


### PR DESCRIPTION
Allow callers of the `Runner` class to optionally specific a `Dictionary` of exit codes and their meanings. This allows for clearer error codes with more information being shown to users.