### PR TITLE
Add time to history

### DIFF
--- a/CCVTAC/CCVTAC.Console/History.cs
+++ b/CCVTAC/CCVTAC.Console/History.cs
@@ -1,19 +1,32 @@
 using System.IO;
+using System.Text.Json;
 
 namespace CCVTAC.Console;
 
+/// <summary>
+/// Handles storing, retrieving, and (eventually) analyzing data relating
+/// to URLs that the user has entered.
+/// </summary>
 public static class History
 {
-    public static void Append(string url, Printer printer)
+    private static readonly string FileName = "history.log";
+    private static readonly char Separator = ';';
+
+    /// <summary>
+    /// Add a URL and related data to the history file.
+    /// </summary>
+    public static void Append(IList<string> urls, DateTime entryTime, Printer printer)
     {
         try
         {
-            File.AppendAllText("history.log", url + Environment.NewLine);
-            printer.Print("Added URL to the history log.");
+            string serializedEntryTime = JsonSerializer.Serialize(entryTime);
+            IEnumerable<string> lines = urls.Select(url => serializedEntryTime + Separator + url);
+            File.AppendAllLines(FileName, lines);
+            printer.Print($"Added {urls.Count} URL{(urls.Count == 1 ? "" : "s")} to the history log.");
         }
         catch (Exception ex)
         {
-            printer.Error($"Could not append URL {url} to history log: " + ex.Message);
+            printer.Error($"Could not append URL(s) to history log: " + ex.Message);
         }
     }
 }

--- a/CCVTAC/CCVTAC.Console/History.cs
+++ b/CCVTAC/CCVTAC.Console/History.cs
@@ -20,14 +20,13 @@ public class History
     /// <summary>
     /// Add a URL and related data to the history file.
     /// </summary>
-    public void Append(IList<string> urls, DateTime entryTime, Printer printer)
+    public void Append(string url, DateTime entryTime, Printer printer)
     {
         try
         {
             string serializedEntryTime = JsonSerializer.Serialize(entryTime);
-            IEnumerable<string> lines = urls.Select(url => serializedEntryTime + Separator + url);
-            File.AppendAllLines(FilePath, lines);
-            printer.Print($"Added {urls.Count} URL{(urls.Count == 1 ? "" : "s")} to the history log.");
+            File.AppendAllText(FilePath, serializedEntryTime + Separator + url + Environment.NewLine);
+            printer.Print($"Added \"{url}\" to the history log.");
         }
         catch (Exception ex)
         {

--- a/CCVTAC/CCVTAC.Console/History.cs
+++ b/CCVTAC/CCVTAC.Console/History.cs
@@ -7,21 +7,26 @@ namespace CCVTAC.Console;
 /// Handles storing, retrieving, and (eventually) analyzing data relating
 /// to URLs that the user has entered.
 /// </summary>
-public static class History
+public class History
 {
-    private static readonly string FileName = "history.log";
     private static readonly char Separator = ';';
+    private string FilePath { get; init; }
+
+    public History(string filePath)
+    {
+        FilePath = filePath;
+    }
 
     /// <summary>
     /// Add a URL and related data to the history file.
     /// </summary>
-    public static void Append(IList<string> urls, DateTime entryTime, Printer printer)
+    public void Append(IList<string> urls, DateTime entryTime, Printer printer)
     {
         try
         {
             string serializedEntryTime = JsonSerializer.Serialize(entryTime);
             IEnumerable<string> lines = urls.Select(url => serializedEntryTime + Separator + url);
-            File.AppendAllLines(FileName, lines);
+            File.AppendAllLines(FilePath, lines);
             printer.Print($"Added {urls.Count} URL{(urls.Count == 1 ? "" : "s")} to the history log.");
         }
         catch (Exception ex)

--- a/CCVTAC/CCVTAC.Console/PostProcessing/Renamer.cs
+++ b/CCVTAC/CCVTAC.Console/PostProcessing/Renamer.cs
@@ -27,7 +27,7 @@ internal static class Renamer
             "%<1>s - ",
             "Remove and reformat duplicate track numbers"),
         new(
-            new Regex(@"\s*[(（【［\[\-]?(?:[Oo]fficial +|OFFICIAL +)?(?:[Mm]usic [Vv]ideo|MUSIC VIDEO|[Ll]yric [Vv]ideo|LYRIC VIDEO|[Vv]ideo|VIDEO|[Aa]udio|[Vv]isualizer|AUDIO|[Ff]ull (?:[Aa]lbum|LP|EP)|M(?:[_/])?V)[)】］）\]\-]?"),
+            new Regex(@"\s*[(（【［\[\-]?(?:[Oo]fficial +|OFFICIAL +)?(?:HD )?(?:[Mm]usic [Vv]ideo|MUSIC VIDEO|[Ll]yric [Vv]ideo|LYRIC VIDEO|[Vv]ideo|VIDEO|[Aa]udio|[Vv]isualizer|AUDIO|[Ff]ull (?:[Aa]lbum|LP|EP)|M(?:[_/])?V)[)】］）\]\-]?"),
             string.Empty,
             "Remove unneeded labels"),
         new(

--- a/CCVTAC/CCVTAC.Console/Program.cs
+++ b/CCVTAC/CCVTAC.Console/Program.cs
@@ -74,10 +74,11 @@ internal static class Program
         }
 
         ResultTracker resultTracker = new(printer);
+        History historyLogger = new(userSettings.HistoryLogFilePath);
 
         while (true)
         {
-            NextAction nextAction = ProcessBatch(userSettings, resultTracker, printer);
+            NextAction nextAction = ProcessBatch(userSettings, resultTracker, historyLogger, printer);
             if (nextAction != NextAction.Continue)
             {
                 break;
@@ -94,7 +95,11 @@ internal static class Program
     /// <param name="resultHandler"></param>
     /// <param name="printer"></param>
     /// <returns>A bool indicating whether to quit the program (true) or continue (false).</returns>
-    private static NextAction ProcessBatch(UserSettings userSettings, ResultTracker resultHandler, Printer printer)
+    private static NextAction ProcessBatch(
+        UserSettings userSettings,
+        ResultTracker resultHandler,
+        History historyLogger,
+        Printer printer)
     {
         string userInput = printer.GetInput(_inputPrompt);
 
@@ -113,7 +118,7 @@ internal static class Program
             printer.PrintEmptyLines(1);
         }
 
-        History.Append(batchUrls, DateTime.Now, printer);
+        historyLogger.Append(batchUrls, DateTime.Now, printer);
 
         nuint currentBatch = 0;
         bool haveProcessedAny = false;

--- a/CCVTAC/CCVTAC.Console/Program.cs
+++ b/CCVTAC/CCVTAC.Console/Program.cs
@@ -113,6 +113,8 @@ internal static class Program
             printer.PrintEmptyLines(1);
         }
 
+        History.Append(batchUrls, DateTime.Now, printer);
+
         nuint currentBatch = 0;
         bool haveProcessedAny = false;
 
@@ -167,8 +169,6 @@ internal static class Program
             {
                 return NextAction.Continue;
             }
-
-            History.Append(url, printer);
 
             var postProcessor = new PostProcessing.Setup(userSettings, printer);
             postProcessor.Run(); // TODO: Think about if/how to handle leftover temp files due to errors.

--- a/CCVTAC/CCVTAC.Console/Program.cs
+++ b/CCVTAC/CCVTAC.Console/Program.cs
@@ -9,7 +9,7 @@ internal static class Program
 {
     private static readonly string[] _helpCommands = ["-h", "--help"];
     private static readonly string[] _quitCommands = ["q", "quit", "exit", "bye"];
-    private const string _inputPrompt = "Enter one or more YouTube resource URLs (or 'q' to quit):";
+    private const string _inputPrompt = "Enter one or more YouTube media URLs (or 'q' to quit):";
 
     static void Main(string[] args)
     {
@@ -102,12 +102,13 @@ internal static class Program
         Printer printer)
     {
         string userInput = printer.GetInput(_inputPrompt);
+        DateTime inputTime = DateTime.Now;
 
         Stopwatch topStopwatch = new();
         topStopwatch.Start();
 
         var batchUrls = userInput.Split(" ")
-                                 .Where(i => i.HasText()) // Remove multiple spaces.
+                                 .Where(i => i.HasText())
                                  .Distinct()
                                  .ToImmutableList();
 
@@ -118,8 +119,6 @@ internal static class Program
             printer.PrintEmptyLines(1);
         }
 
-        historyLogger.Append(batchUrls, DateTime.Now, printer);
-
         nuint currentBatch = 0;
         bool haveProcessedAny = false;
 
@@ -129,6 +128,8 @@ internal static class Program
             {
                 return NextAction.QuitAtUserRequest;
             }
+
+            historyLogger.Append(url, inputTime, printer);
 
             var tempFiles = IoUtilties.Directories.GetDirectoryFiles(userSettings.WorkingDirectory);
             if (tempFiles.Any())

--- a/CCVTAC/CCVTAC.Console/Settings/SettingsService.cs
+++ b/CCVTAC/CCVTAC.Console/Settings/SettingsService.cs
@@ -37,6 +37,7 @@ public static class SettingsService
             },
             { "Working directory", settings.WorkingDirectory },
             { "Move-to directory", settings.MoveToDirectory },
+            { "History log file", settings.HistoryLogFilePath },
         }.ToImmutableList();
 
         var table = new Table();

--- a/CCVTAC/CCVTAC.Console/Settings/SettingsService.cs
+++ b/CCVTAC/CCVTAC.Console/Settings/SettingsService.cs
@@ -19,6 +19,10 @@ public static class SettingsService
         if (header.HasText())
             printer.Print(header!);
 
+        string historyFileNote = File.Exists(settings.HistoryLogFilePath)
+            ? "exists"
+            : "will be created";
+
         var settingPairs = new Dictionary<string, string>()
         {
             { $"Audio file format", settings.AudioFormat.ToUpperInvariant() },
@@ -37,7 +41,7 @@ public static class SettingsService
             },
             { "Working directory", settings.WorkingDirectory },
             { "Move-to directory", settings.MoveToDirectory },
-            { "History log file", settings.HistoryLogFilePath },
+            { "History log file", $"{settings.HistoryLogFilePath} ({historyFileNote})" },
         }.ToImmutableList();
 
         var table = new Table();
@@ -52,15 +56,15 @@ public static class SettingsService
 
         printer.Print(table);
 
-        static string PluralizeIfNeeded(string term, int count)
+        static string PluralizeIfNeeded(string singularTerm, int count)
         {
-            return (term, count) switch
+            return (singularTerm, count) switch
             {
-                { term: "second", count: 1 } => term,
-                { term: "second", count: _ } => "seconds",
-                { term: "channel", count: 1 } => term,
-                { term: "channel", count: _ } => "channels",
-                _ => term
+                { singularTerm: "second", count: 1 } => singularTerm,
+                { singularTerm: "second", count: _ } => "seconds",
+                { singularTerm: "channel", count: 1 } => singularTerm,
+                { singularTerm: "channel", count: _ } => "channels",
+                _ => singularTerm
             };
         }
     }

--- a/CCVTAC/CCVTAC.Console/Settings/UserSettings.cs
+++ b/CCVTAC/CCVTAC.Console/Settings/UserSettings.cs
@@ -27,6 +27,13 @@ public sealed class UserSettings
     public string MoveToDirectory { get; init; } = string.Empty;
 
     /// <summary>
+    /// The file to which history should be logged.
+    /// </summary>
+    [JsonPropertyName("historyLog")]
+    [JsonRequired]
+    public string HistoryLogFilePath { get; init; } = string.Empty;
+
+    /// <summary>
     /// Specifies whether video chapters should be split into a separate
     /// audio files (true) or instead be ignored such that there is one combined
     /// audio file for the entire video (false). Defaults to true.


### PR DESCRIPTION
- Add times to the history log file. The times are the exact time the user entered the batch, so all URLs in the same batch will have identical times. Older entries, which have no time, are left as-is.
- Make the history file path a setting.
- Append times before downloading begins.