### PR TITLE
Differentiate between regular and "release" playlists

### DIFF
--- a/CCVTAC/CCVTAC.Console/Downloading/Downloader.cs
+++ b/CCVTAC/CCVTAC.Console/Downloading/Downloader.cs
@@ -133,6 +133,15 @@ internal static class Downloader
             args.Add($"--sleep-interval {settings.SleepSecondsBetweenDownloads}");
         }
 
+        // The numbering of regular playlists should be reversed because the newest items are
+        // always placed at the top of the list at position #1. Instead, the oldest items
+        // (at the end of the list) should begin at #1.
+        if (downloadType is DownloadType.Media &&
+            videoDownloadType is MediaDownloadType.Playlist)
+        {
+            args.Add("""-o "%(playlist)s = %(playlist_autonumber)s - %(title)s [%(id)s].%(ext)s" --playlist-reverse""");
+        }
+
         return string.Join(" ", args.Concat(additionalArgs ?? Enumerable.Empty<string>()));
     }
 }

--- a/CCVTAC/CCVTAC.Console/Downloading/Entities/DownloadEntityFactory.cs
+++ b/CCVTAC/CCVTAC.Console/Downloading/Entities/DownloadEntityFactory.cs
@@ -12,6 +12,7 @@ public static class DownloadEntityFactory
         { MediaDownloadType.VideoOnPlaylist, VideoOnPlaylist.Regexes },
         { MediaDownloadType.Video,           Video.Regexes },
         { MediaDownloadType.Playlist,        Playlist.Regexes },
+        { MediaDownloadType.ReleasePlaylist, ReleasePlaylist.Regexes },
         { MediaDownloadType.Channel,         Channel.Regexes }
     };
 
@@ -35,13 +36,15 @@ public static class DownloadEntityFactory
             return Result.Fail("Unsupported or invalid URL. (No matching URL found.)");
         }
 
-        (MediaDownloadType type, string resourceId, string? supplementaryResourceId) = typesWithResourceIds.First();
+        (MediaDownloadType type, string resourceId, string? supplementaryResourceId) =
+            typesWithResourceIds.First();
 
         return type switch
         {
             MediaDownloadType.VideoOnPlaylist => Result.Ok((IDownloadEntity) new VideoOnPlaylist(resourceId, supplementaryResourceId!)),
             MediaDownloadType.Video =>           Result.Ok((IDownloadEntity) new Video(resourceId)),
             MediaDownloadType.Playlist =>        Result.Ok((IDownloadEntity) new Playlist(resourceId)),
+            MediaDownloadType.ReleasePlaylist => Result.Ok((IDownloadEntity) new ReleasePlaylist(resourceId)),
             MediaDownloadType.Channel=>          Result.Ok((IDownloadEntity) new Channel(resourceId)),
             _ =>                                 Result.Fail("Unsupported or invalid URL. (No matching download type found.)")
         };

--- a/CCVTAC/CCVTAC.Console/Downloading/Entities/ReleasePlaylist.cs
+++ b/CCVTAC/CCVTAC.Console/Downloading/Entities/ReleasePlaylist.cs
@@ -3,24 +3,24 @@ using System.Text.RegularExpressions;
 namespace CCVTAC.Console.Downloading.Entities;
 
 /// <summary>
-/// A single playlist which contains at least one video.
+/// A single release-based playlist which contains at least one video.
 /// </summary>
-public sealed class Playlist : IDownloadEntity
+public sealed class ReleasePlaylist : IDownloadEntity
 {
     public static IEnumerable<Regex> Regexes => new List<Regex>
     {
-        new(@"(?<=list=)(P[\w\-]+)")
+        new(@"(?<=list=)(O[\w\-]+)")
     };
 
     public DownloadType DownloadType => DownloadType.Media;
-    public MediaDownloadType VideoDownloadType => MediaDownloadType.Playlist;
+    public MediaDownloadType VideoDownloadType => MediaDownloadType.ReleasePlaylist;
 
     public static string UrlBase => "https://www.youtube.com/playlist?list=";
 
     public ResourceUrlSet PrimaryResource { get; init; }
     public ResourceUrlSet? SupplementaryResource { get; init; }
 
-    public Playlist(string resourceId)
+    public ReleasePlaylist(string resourceId)
     {
         PrimaryResource = new ResourceUrlSet(UrlBase, resourceId.Trim());
     }

--- a/CCVTAC/CCVTAC.Console/Downloading/MediaDownloadType.cs
+++ b/CCVTAC/CCVTAC.Console/Downloading/MediaDownloadType.cs
@@ -16,9 +16,16 @@ public enum MediaDownloadType
     VideoOnPlaylist,
 
     /// <summary>
-    /// A playlist containing 1 or more videos.
+    /// A playlist containing 1 or more videos. They are considered mutable, as new items
+    /// might be added gradually at later dates.
     /// </summary>
     Playlist,
+
+    /// <summary>
+    /// A release playlist (as seen on the Releases tab on YouTube) containing 1 or more videos.
+    /// They are considered to be immutable and of the correct order.
+    /// </summary>
+    ReleasePlaylist,
 
     /// <summary>
     /// A user's channel, containing 1 or more videos.


### PR DESCRIPTION
I realized today that there are two kinds of playlist on YouTube:

1. Ones whose IDs begin with `PL`, which are regular playlists and might have videos added to them at a later date.
2. Ones whose IDs begin with `OL`, which I'm calling "release playlists" (though "ordered playlists" might be a better name?) and are visible on the Release tabs on some YouTube channels. I'm considering these to be immutable.

Since release playlists (likely) do not have updates, we can use their numbering (video indexing) as-is.

However, regular playlists might have new videos added, and it appears that those new videos are always added to the top of the playlist. This means that the video with index 1 (representing the top of the playlist) changes over time, and that the index of the first video uploaded to the playlist increases over time as new videos are added.

I realized that it would make more sense for regular playlists to be numbered in reverse order, which yt-dlp lucky supports via its `--reverse-playlist` flag.

This PR does the following:
1. Adds the playlist name and reversed-ordered index to video filenames (not tags—see below)
2. Adds a new `ReleasePlaylist` type, which has the same behavior that playlists have had until now (e.g., standard from-the-top numbering)

_Note:_ Even though the filenames of audio files from regular playlists will be numbered backwards, the original from-the-top index from the video on the playlist will still be added to the files' track tags. This allows you the option to keep the original numbering, if desired for certain cases, or else to use a tool like [my AudioTagger tool](https://github.com/codeconscious/audiotagger) (which I plan to use) to use the filename data to update the track tags.