### PR TITLE
Allow custom settings files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .DS_Store
 history.log
 settings.json
+*.bak
 local_testing
 
 ## Ignore Visual Studio temporary files, build results, and

--- a/CCVTAC/CCVTAC.Console/History.cs
+++ b/CCVTAC/CCVTAC.Console/History.cs
@@ -37,7 +37,7 @@ public class History
         }
     }
 
-    public void DisplayRecent(Printer printer)
+    public void ShowRecent(Printer printer)
     {
         try
         {

--- a/CCVTAC/CCVTAC.Console/History.cs
+++ b/CCVTAC/CCVTAC.Console/History.cs
@@ -1,19 +1,36 @@
 using System.IO;
+using System.Text.Json;
 
 namespace CCVTAC.Console;
 
-public static class History
+/// <summary>
+/// Handles storing, retrieving, and (eventually) analyzing data relating
+/// to URLs that the user has entered.
+/// </summary>
+public class History
 {
-    public static void Append(string url, Printer printer)
+    private static readonly char Separator = ';';
+    private string FilePath { get; init; }
+
+    public History(string filePath)
+    {
+        FilePath = filePath;
+    }
+
+    /// <summary>
+    /// Add a URL and related data to the history file.
+    /// </summary>
+    public void Append(string url, DateTime entryTime, Printer printer)
     {
         try
         {
-            File.AppendAllText("history.log", url + Environment.NewLine);
-            printer.Print("Added URL to the history log.");
+            string serializedEntryTime = JsonSerializer.Serialize(entryTime);
+            File.AppendAllText(FilePath, serializedEntryTime + Separator + url + Environment.NewLine);
+            printer.Print($"Added \"{url}\" to the history log.");
         }
         catch (Exception ex)
         {
-            printer.Error($"Could not append URL {url} to history log: " + ex.Message);
+            printer.Error($"Could not append URL(s) to history log: " + ex.Message);
         }
     }
 }

--- a/CCVTAC/CCVTAC.Console/PostProcessing/Renamer.cs
+++ b/CCVTAC/CCVTAC.Console/PostProcessing/Renamer.cs
@@ -27,7 +27,7 @@ internal static class Renamer
             "%<1>s - ",
             "Remove and reformat duplicate track numbers"),
         new(
-            new Regex(@"\s*[(（【［\[\-]?(?:[Oo]fficial +|OFFICIAL +)?(?:[Mm]usic [Vv]ideo|MUSIC VIDEO|[Ll]yric [Vv]ideo|LYRIC VIDEO|[Vv]ideo|VIDEO|[Aa]udio|[Vv]isualizer|AUDIO|[Ff]ull (?:[Aa]lbum|LP|EP)|M(?:[_/])?V)[)】］）\]\-]?"),
+            new Regex(@"\s*[(（【［\[\-]?(?:[Oo]fficial +|OFFICIAL +)?(?:HD )?(?:[Mm]usic [Vv]ideo|MUSIC VIDEO|[Ll]yric [Vv]ideo|LYRIC VIDEO|[Vv]ideo|VIDEO|[Aa]udio|[Vv]isualizer|AUDIO|[Ff]ull (?:[Aa]lbum|LP|EP)|M(?:[_/])?V)[)】］）\]\-]?"),
             string.Empty,
             "Remove unneeded labels"),
         new(

--- a/CCVTAC/CCVTAC.Console/Program.cs
+++ b/CCVTAC/CCVTAC.Console/Program.cs
@@ -26,9 +26,9 @@ internal static class Program
         string? maybeSettingsPath = args.Length >= 2 && _settingsFileCommands.Contains(args[0].ToLowerInvariant())
                 ? args[1] // Expected to be a settings file path.
                 : null;
-        var settingsService = new SettingsService(maybeSettingsPath);
+        SettingsService settingsService = new(maybeSettingsPath);
 
-        Result<UserSettings> settingsResult = settingsService.PrepareUserSettings();
+        var settingsResult = settingsService.PrepareUserSettings();
         if (settingsResult.IsFailed)
         {
             printer.Errors("Settings error(s):", settingsResult);

--- a/CCVTAC/CCVTAC.Console/Program.cs
+++ b/CCVTAC/CCVTAC.Console/Program.cs
@@ -21,6 +21,17 @@ internal static class Program
             return;
         }
 
+        if (!SettingsService.DoesFileExist())
+        {
+            SettingsService.WriteDefaultFile();
+            printer.Print("""
+                A new empty settings file was created in the directory containing this application.
+                Please review it and populate it with your desired settings.
+                In particular, "workingDirectory," "moveToDirectory," and "historyPath" must be populated.
+                """);
+            return;
+        }
+
         // Catch the user's pressing Ctrl-C (SIGINT).
         System.Console.CancelKeyPress += delegate
         {

--- a/CCVTAC/CCVTAC.Console/Program.cs
+++ b/CCVTAC/CCVTAC.Console/Program.cs
@@ -61,15 +61,15 @@ internal static class Program
             return;
         }
         UserSettings userSettings = settingsResult.Value;
+        settingsService.PrintSummary(userSettings, printer, header: "Settings loaded OK.");
 
         History history = new(userSettings.HistoryFilePath, userSettings.HistoryDisplayCount);
 
         if (args.Length > 0 && _historyCommands.Contains(args[0].ToLowerInvariant()))
         {
-            history.DisplayRecent(printer);
+            history.ShowRecent(printer);
             return;
         }
-
 
         // Catch the user's pressing Ctrl-C (SIGINT).
         System.Console.CancelKeyPress += delegate
@@ -80,7 +80,7 @@ internal static class Program
         // Top-level `try` block to catch and pretty-print unexpected exceptions.
         try
         {
-            Start(userSettings, settingsService, history, printer);
+            Start(userSettings, history, printer);
         }
         catch (Exception topException)
         {
@@ -93,7 +93,7 @@ internal static class Program
     /// <summary>
      /// Performs initial setup, initiates each download request, and prints the final summary when the user requests to end the program.
     /// </summary>
-    private static void Start(UserSettings userSettings, SettingsService settingsService, History history, Printer printer)
+    private static void Start(UserSettings userSettings, History history, Printer printer)
     {
         // Verify the external program for downloading is installed on the system.
         if (Downloading.Downloader.ExternalProgram.ProgramExists() is { IsFailed: true })
@@ -104,14 +104,6 @@ internal static class Program
             printer.Print("Pass '--help' to this program for more information.");
             return;
         }
-
-        var settingsResult = settingsService.GetUserSettings();
-        if (settingsResult.IsFailed)
-        {
-            printer.Errors("Settings file errors:", settingsResult);
-            return;
-        }
-        SettingsService.PrintSummary(userSettings, printer, "Settings loaded OK.");
 
         // The working directory should be empty.
         var tempFiles = IoUtilties.Directories.GetDirectoryFiles(userSettings.WorkingDirectory);
@@ -179,7 +171,7 @@ internal static class Program
 
             if (_historyCommands.Contains(url.ToLowerInvariant()))
             {
-                history.DisplayRecent(printer);
+                history.ShowRecent(printer);
                 continue;
             }
 

--- a/CCVTAC/CCVTAC.Console/Settings/SettingsService.cs
+++ b/CCVTAC/CCVTAC.Console/Settings/SettingsService.cs
@@ -12,6 +12,129 @@ public class SettingsService(string? customFilePath = null)
                                                     AppContext.BaseDirectory,
                                                     _defaultSettingsFileName);
 
+    public Result<UserSettings> PrepareUserSettings()
+    {
+        if (File.Exists(FullPath))
+        {
+            var getSettingsResult = GetExistingSettings();
+            if (getSettingsResult.IsFailed)
+                return getSettingsResult;
+
+            return Result.Ok(getSettingsResult.Value);
+        }
+
+        if (WriteDefaultFile() is { IsFailed: true } failedResult)
+        {
+            return Result.Fail($"Could not write a new settings file: {failedResult.Errors.Select(e => e.Message).First()}");
+        }
+
+        // Using `Fail` to indicate that the program cannot continue as is, though the write operation was successful.
+        return Result.Fail(
+            $"A new empty settings file was created at \"{FullPath}\"." +
+            """
+            Please review it and populate it with your desired settings.
+            In particular, "workingDirectory," "moveToDirectory," and "historyFilePath" must be populated.
+            """);
+    }
+
+    private Result<UserSettings> GetExistingSettings()
+    {
+        UserSettings settings;
+        try
+        {
+            string json = File.ReadAllText(FullPath);
+            settings = JsonSerializer.Deserialize<UserSettings>(json)
+                       ?? throw new JsonException();
+        }
+        catch (FileNotFoundException)
+        {
+            return Result.Fail($"Settings file \"{FullPath}\" not found.");
+        }
+        catch (JsonException ex)
+        {
+            return Result.Fail($"Settings file JSON at \"{FullPath}\" is invalid: {ex.Message}");
+        }
+
+        if (EnsureValidSettings(settings) is { IsFailed: true} failedResult)
+            return Result.Fail(failedResult.Errors.Select(e => e.Message));
+
+        // Ensure ID3 version 2.3, which seems more widely supported than version 2.4.
+        TagFormat.SetId3v2Version(
+            version: TagFormat.Id3v2Version.TwoPoint3,
+            forceAsDefault: true);
+
+        return Result.Ok(settings);
+    }
+
+    /// <summary>
+    /// Creates the specified settings file if it is missing. Otherwise, does nothing.
+    /// </summary>
+    /// <returns>A Result indicating success or no action (Ok) or else failure (Fail).</returns>
+    private Result WriteDefaultFile()
+    {
+        try
+        {
+            return WriteFile(new UserSettings());
+        }
+        catch (Exception ex)
+        {
+            return Result.Fail($"Error creating \"{FullPath}\": {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Write settings to the specified file.
+    /// </summary>
+    /// <param name="settings"></param>
+    /// <param name="printer"></param>
+    private Result WriteFile(UserSettings settings)
+    {
+        try
+        {
+            string json = JsonSerializer.Serialize(
+                settings,
+                new JsonSerializerOptions
+                {
+                    WriteIndented = true,
+                    Encoder = System.Text.Encodings.Web.JavaScriptEncoder.Create(
+                                 System.Text.Unicode.UnicodeRanges.All)
+                });
+            File.WriteAllText(FullPath, json);
+            return Result.Ok();
+        }
+        catch (FileNotFoundException)
+        {
+            return Result.Fail($"Settings file \"{FullPath}\" is missing.");
+        }
+        catch (JsonException ex)
+        {
+            return Result.Fail($"Invalid JSON in settings file: {ex.Message}.");
+        }
+    }
+
+    /// <summary>
+    /// Ensure the mandatory settings are present and valid.
+    /// </summary>
+    /// <returns>A Result indicating success or failure.</returns>
+    private static Result EnsureValidSettings(UserSettings settings)
+    {
+        List<string> errors = [];
+
+        if (string.IsNullOrWhiteSpace(settings.MoveToDirectory))
+            errors.Add($"No move-to directory was specified in the settings.");
+        else if (!Directory.Exists(settings.MoveToDirectory))
+            errors.Add($"Move-to directory \"{settings.MoveToDirectory}\" does not exist.");
+
+        if (string.IsNullOrWhiteSpace(settings.WorkingDirectory))
+            errors.Add($"No working directory was specified in the settings.");
+        else if (!Directory.Exists(settings.WorkingDirectory))
+            errors.Add($"Working directory \"{settings.WorkingDirectory}\" does not exist.");
+
+        return errors.Any()
+            ? Result.Fail(errors)
+            : Result.Ok();
+    }
+
     /// <summary>
     /// Prints a summary of the given settings.
     /// </summary>
@@ -76,109 +199,5 @@ public class SettingsService(string? customFilePath = null)
                 _ => singularTerm
             };
         }
-    }
-
-    public Result<UserSettings> GetUserSettings()
-    {
-        UserSettings settings;
-        try
-        {
-            string json = File.ReadAllText(FullPath);
-            settings = JsonSerializer.Deserialize<UserSettings>(json)
-                       ?? throw new JsonException();
-        }
-        catch (FileNotFoundException)
-        {
-            return Result.Fail($"Settings file \"{FullPath}\" not found.");
-        }
-        catch (JsonException ex)
-        {
-            return Result.Fail($"Settings file JSON is invalid: {ex.Message}");
-        }
-
-        if (EnsureValidSettings(settings) is { IsFailed: true} failedResult)
-            return Result.Fail(failedResult.Errors.Select(e => e.Message));
-
-        // Ensure ID3 version 2.3, which seems more widely supported than version 2.4.
-        TagFormat.SetId3v2Version(
-            version: TagFormat.Id3v2Version.TwoPoint3,
-            forceAsDefault: true);
-
-        return Result.Ok(settings);
-    }
-
-    public bool DoesFileExist()
-    {
-        return File.Exists(FullPath);
-    }
-
-    /// <summary>
-    /// Creates the specified settings file if it is missing. Otherwise, does nothing.
-    /// </summary>
-    /// <returns>A Result indicating success or no action (Ok) or else failure (Fail).</returns>
-    public Result WriteDefaultFile()
-    {
-        try
-        {
-            return Write(new UserSettings());
-        }
-        catch (Exception ex)
-        {
-            return Result.Fail($"Error creating \"{FullPath}\": {ex.Message}");
-        }
-    }
-
-    /// <summary>
-    /// Write settings to the specified file.
-    /// </summary>
-    /// <param name="settings"></param>
-    /// <param name="printer"></param>
-    /// <returns>A Result indicating success or failure.</returns>
-    private Result Write(UserSettings settings)
-    {
-        try
-        {
-            string json = JsonSerializer.Serialize(
-                settings,
-                new JsonSerializerOptions
-                {
-                    WriteIndented = true,
-                    Encoder = System.Text.Encodings.Web.JavaScriptEncoder.Create(
-                                 System.Text.Unicode.UnicodeRanges.All)
-                });
-            File.WriteAllText(FullPath, json);
-            return Result.Ok();
-        }
-        catch (FileNotFoundException)
-        {
-            return Result.Fail($"Settings file \"{FullPath}\" is missing.");
-        }
-        catch (JsonException ex)
-        {
-            return Result.Fail($"Invalid JSON in settings file: {ex.Message}.");
-        }
-    }
-
-    /// <summary>
-    /// Ensure the mandatory settings are present and valid.
-    /// </summary>
-    /// <returns>A Result indicating success or failure.</returns>
-    private static Result EnsureValidSettings(UserSettings settings)
-    {
-        List<string> errors = [];
-
-        if (string.IsNullOrWhiteSpace(settings.MoveToDirectory))
-            errors.Add($"No move-to directory was specified in the settings.");
-        else if (!Directory.Exists(settings.MoveToDirectory))
-            errors.Add($"Move-to directory \"{settings.MoveToDirectory}\" does not exist.");
-
-        if (string.IsNullOrWhiteSpace(settings.WorkingDirectory))
-            errors.Add($"No working directory was specified in the settings.");
-        else if (!Directory.Exists(settings.WorkingDirectory))
-            errors.Add($"Working directory \"{settings.WorkingDirectory}\" does not exist.");
-
-        return errors.Any()
-            ? Result.Fail(errors)
-            : Result.Ok();
     }
 }

--- a/CCVTAC/CCVTAC.Console/Settings/SettingsService.cs
+++ b/CCVTAC/CCVTAC.Console/Settings/SettingsService.cs
@@ -30,27 +30,6 @@ public class SettingsService(string? customFilePath = null)
             ? "exists"
             : "will be created";
 
-        var settingPairs = new Dictionary<string, string>()
-        {
-            { $"Audio file format", settings.AudioFormat.ToUpperInvariant() },
-            { $"Split video chapters", settings.SplitChapters ? "ON" : "OFF" },
-            {
-                $"Sleep between batches",
-                $"{settings.SleepSecondsBetweenBatches} {PluralizeIfNeeded("second", settings.SleepSecondsBetweenBatches)}"
-            },
-            {
-                $"Sleep between downloads",
-                $"{settings.SleepSecondsBetweenDownloads} {PluralizeIfNeeded("second", settings.SleepSecondsBetweenDownloads)}"
-            },
-            {
-                $"Ignore-upload-year channels",
-                $"{settings.IgnoreUploadYearUploaders?.Length.ToString() ?? "No"} {PluralizeIfNeeded("channel", settings.IgnoreUploadYearUploaders?.Length ?? 0)}"
-            },
-            { "Working directory", settings.WorkingDirectory },
-            { "Move-to directory", settings.MoveToDirectory },
-            { "History log file", $"{settings.HistoryFilePath} ({historyFileNote})" },
-        }.ToImmutableList();
-
         var table = new Table();
         table.Expand();
         table.Border(TableBorder.HeavyEdge);
@@ -58,6 +37,29 @@ public class SettingsService(string? customFilePath = null)
         table.AddColumns("Name", "Value");
         table.HideHeaders();
         table.Columns[1].Width = 100; // Ensure its at maximum width.
+
+        ImmutableList<KeyValuePair<string, string>> settingPairs =
+            new Dictionary<string, string>()
+                {
+                    { $"Audio file format", settings.AudioFormat.ToUpperInvariant() },
+                    { $"Split video chapters", settings.SplitChapters ? "ON" : "OFF" },
+                    {
+                        $"Sleep between batches",
+                        $"{settings.SleepSecondsBetweenBatches} {PluralizeIfNeeded("second", settings.SleepSecondsBetweenBatches)}"
+                    },
+                    {
+                        $"Sleep between downloads",
+                        $"{settings.SleepSecondsBetweenDownloads} {PluralizeIfNeeded("second", settings.SleepSecondsBetweenDownloads)}"
+                    },
+                    {
+                        $"Ignore-upload-year channels",
+                        $"{settings.IgnoreUploadYearUploaders?.Length.ToString() ?? "No"} {PluralizeIfNeeded("channel", settings.IgnoreUploadYearUploaders?.Length ?? 0)}"
+                    },
+                    { "Working directory", settings.WorkingDirectory },
+                    { "Move-to directory", settings.MoveToDirectory },
+                    { "History log file", $"{settings.HistoryFilePath} ({historyFileNote})" },
+                }
+            .ToImmutableList();
 
         settingPairs.ForEach(pair => table.AddRow(pair.Key, pair.Value));
 

--- a/CCVTAC/CCVTAC.Console/Settings/SettingsService.cs
+++ b/CCVTAC/CCVTAC.Console/Settings/SettingsService.cs
@@ -18,7 +18,7 @@ public class SettingsService(string? customFilePath = null)
     /// <param name="settings"></param>
     /// <param name="printer"></param>
     /// <param name="header">An optional line of text to appear above the settings.</param>
-    public static void PrintSummary(
+    public void PrintSummary(
         UserSettings settings,
         Printer printer,
         string? header = null)

--- a/CCVTAC/CCVTAC.Console/Settings/SettingsService.cs
+++ b/CCVTAC/CCVTAC.Console/Settings/SettingsService.cs
@@ -19,6 +19,10 @@ public static class SettingsService
         if (header.HasText())
             printer.Print(header!);
 
+        string historyFileNote = File.Exists(settings.HistoryLogFilePath)
+            ? "exists"
+            : "will be created";
+
         var settingPairs = new Dictionary<string, string>()
         {
             { $"Audio file format", settings.AudioFormat.ToUpperInvariant() },
@@ -37,6 +41,7 @@ public static class SettingsService
             },
             { "Working directory", settings.WorkingDirectory },
             { "Move-to directory", settings.MoveToDirectory },
+            { "History log file", $"{settings.HistoryLogFilePath} ({historyFileNote})" },
         }.ToImmutableList();
 
         var table = new Table();
@@ -51,15 +56,15 @@ public static class SettingsService
 
         printer.Print(table);
 
-        static string PluralizeIfNeeded(string term, int count)
+        static string PluralizeIfNeeded(string singularTerm, int count)
         {
-            return (term, count) switch
+            return (singularTerm, count) switch
             {
-                { term: "second", count: 1 } => term,
-                { term: "second", count: _ } => "seconds",
-                { term: "channel", count: 1 } => term,
-                { term: "channel", count: _ } => "channels",
-                _ => term
+                { singularTerm: "second", count: 1 } => singularTerm,
+                { singularTerm: "second", count: _ } => "seconds",
+                { singularTerm: "channel", count: 1 } => singularTerm,
+                { singularTerm: "channel", count: _ } => "channels",
+                _ => singularTerm
             };
         }
     }

--- a/CCVTAC/CCVTAC.Console/Settings/UserSettings.cs
+++ b/CCVTAC/CCVTAC.Console/Settings/UserSettings.cs
@@ -29,9 +29,9 @@ public sealed class UserSettings
     /// <summary>
     /// The file to which history should be logged.
     /// </summary>
-    [JsonPropertyName("historyLog")]
+    [JsonPropertyName("historyFilePath")]
     [JsonRequired]
-    public string HistoryLogFilePath { get; init; } = string.Empty;
+    public string HistoryFilePath { get; init; } = string.Empty;
 
     /// <summary>
     /// Specifies whether video chapters should be split into a separate
@@ -42,8 +42,8 @@ public sealed class UserSettings
     public bool SplitChapters { get; init; } = true;
 
     /// <summary>
-    /// The audio file format that should be downloaded. It must be
-    /// a format supported by both yt-dlp and TagLib#.
+    /// The audio file format that should be downloaded. It must be a format supported
+    /// by both yt-dlp and TagLib# (the tag-editing library used by this program).
     /// </summary>
     /// <remarks>I'm only supporting M4A, which requires no conversion, for now. (See PR #21.)</remarks>
     [JsonPropertyName("audioFormat")]

--- a/CCVTAC/CCVTAC.Console/Settings/UserSettings.cs
+++ b/CCVTAC/CCVTAC.Console/Settings/UserSettings.cs
@@ -27,6 +27,13 @@ public sealed class UserSettings
     public string MoveToDirectory { get; init; } = string.Empty;
 
     /// <summary>
+    /// The file to which history should be logged.
+    /// </summary>
+    [JsonPropertyName("historyLog")]
+    [JsonRequired]
+    public string HistoryLogFilePath { get; init; } = string.Empty;
+
+    /// <summary>
     /// Specifies whether video chapters should be split into a separate
     /// audio files (true) or instead be ignored such that there is one combined
     /// audio file for the entire video (false). Defaults to true.


### PR DESCRIPTION
- Allow users to pass `-s` and a path to their settings paths. This removes the restriction of the settings file being in the program directory.
- Renames the history setting's JSON name to `historyFilePath`.