### PR TITLE
Tweak verbosity logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 *.profraw
 .DS_Store
 history.log
-settings.json
+*.json
 *.bak
 local_testing
 

--- a/CCVTAC/CCVTAC.Console/Downloading/Downloader.cs
+++ b/CCVTAC/CCVTAC.Console/Downloading/Downloader.cs
@@ -19,7 +19,7 @@ internal static class Downloader
     internal static Dictionary<int, string> DownloaderExitCodes = new()
     {
         { 0, "Success" },
-        { 1, "Unspecific error" },
+        { 1, "Unspecified error" },
         { 2, "Error in provided options" },
         { 100, "yt-dlp must restart for update to complete" },
         { 101, "Download cancelled by --max-downloads, etc." },
@@ -102,14 +102,18 @@ internal static class Downloader
                                                MediaDownloadType? videoDownloadType,
                                                params string[]? additionalArgs)
     {
+        const string writeJson = "--write-info-json";
+        const string trim = "--trim-filenames 250";
+
         HashSet<string> args = downloadType switch
         {
-            DownloadType.Metadata => [ "--flat-playlist --write-info-json" ],
+            DownloadType.Metadata => [ $"--flat-playlist {writeJson} {trim}" ],
             _ => [
                      $"--extract-audio -f {settings.AudioFormat}",
                      "--write-thumbnail --convert-thumbnails jpg", // For album art
-                     "--write-info-json", // For parsing metadata
-                     "--retries 3" // Default is 10, more than necessary
+                     writeJson, // For parsing metadata
+                     trim,
+                     "--retries 3", // Default is 10, more than necessary
                  ]
         };
 
@@ -132,10 +136,14 @@ internal static class Downloader
         // The numbering of regular playlists should be reversed because the newest items are
         // always placed at the top of the list at position #1. Instead, the oldest items
         // (at the end of the list) should begin at #1.
-        if (downloadType is DownloadType.Media &&
+        if (downloadType is DownloadType.Media && // This seems superfluous given the next line.
             videoDownloadType is MediaDownloadType.Playlist)
         {
-            args.Add("""-o "%(playlist)s = %(playlist_autonumber)s - %(title)s [%(id)s].%(ext)s" --playlist-reverse""");
+            // The digits followed by `B` induce trimming to the specified number of bytes.
+            // Use `s` instead of `B` to trim to a specified number of characters.
+            // Reference: https://github.com/yt-dlp/yt-dlp/issues/1136#issuecomment-1114252397
+            // Also, it's possible this trimming should be applied to `ReleasePlaylist`s too.
+            args.Add("""-o "%(playlist).80B = %(playlist_autonumber)s - %(title).150B [%(id)s].%(ext)s" --playlist-reverse""");
         }
 
         return string.Join(" ", args.Concat(additionalArgs ?? []));

--- a/CCVTAC/CCVTAC.Console/Downloading/Downloader.cs
+++ b/CCVTAC/CCVTAC.Console/Downloading/Downloader.cs
@@ -120,7 +120,7 @@ internal static class Downloader
             args.Add("--split-chapters");
         }
 
-        args.Add(settings.VerboseOutput ? "--verbose" : "--progress"); // Deciding about `--quiet`.
+        args.Add(settings.VerboseOutput ? string.Empty : "--quiet --progress"); // Deciding about `--verbose`.
 
         if (downloadType is DownloadType.Media &&
             videoDownloadType is not MediaDownloadType.Video &&

--- a/CCVTAC/CCVTAC.Console/Downloading/Downloader.cs
+++ b/CCVTAC/CCVTAC.Console/Downloading/Downloader.cs
@@ -120,7 +120,7 @@ internal static class Downloader
             args.Add("--split-chapters");
         }
 
-        args.Add(settings.VerboseDownloaderOutput ? "--verbose" : "--quiet --progress");
+        args.Add(settings.VerboseOutput ? "--verbose" : "--quiet --progress");
 
         if (downloadType is DownloadType.Media &&
             videoDownloadType is not MediaDownloadType.Video &&

--- a/CCVTAC/CCVTAC.Console/Downloading/Downloader.cs
+++ b/CCVTAC/CCVTAC.Console/Downloading/Downloader.cs
@@ -120,7 +120,7 @@ internal static class Downloader
             args.Add("--split-chapters");
         }
 
-        args.Add(settings.VerboseOutput ? "--verbose" : "--quiet --progress");
+        args.Add(settings.VerboseOutput ? "--verbose" : "--progress"); // Deciding about `--quiet`.
 
         if (downloadType is DownloadType.Media &&
             videoDownloadType is not MediaDownloadType.Video &&

--- a/CCVTAC/CCVTAC.Console/Downloading/Downloader.cs
+++ b/CCVTAC/CCVTAC.Console/Downloading/Downloader.cs
@@ -15,7 +15,7 @@ internal static class Downloader
     /// <summary>
     /// All known error codes returned by yt-dlp with their meanings.
     /// </summary>
-    /// <remarks>Source of error codes: https://github.com/yt-dlp/yt-dlp/issues/4262#issuecomment-1173133105</remarks>
+    /// <remarks>Source: https://github.com/yt-dlp/yt-dlp/issues/4262#issuecomment-1173133105</remarks>
     internal static Dictionary<int, string> DownloaderExitCodes = new()
     {
         { 0, "Success" },
@@ -25,9 +25,7 @@ internal static class Downloader
         { 101, "Download cancelled by --max-downloads, etc." },
     };
 
-    internal static Result<string> Run(string url,
-                                       UserSettings userSettings,
-                                       Printer printer)
+    internal static Result<string> Run(string url, UserSettings userSettings, Printer printer)
     {
         Watch watch = new();
 
@@ -120,7 +118,9 @@ internal static class Downloader
             args.Add("--split-chapters");
         }
 
-        args.Add(settings.VerboseOutput ? string.Empty : "--quiet --progress"); // Deciding about `--verbose`.
+        // `--verbose` is a yt-dlp option too, but maybe that's too much data.
+        // It might be worth incorporating it in the future as a third option.
+        args.Add(settings.VerboseOutput ? string.Empty : "--quiet --progress");
 
         if (downloadType is DownloadType.Media &&
             videoDownloadType is not MediaDownloadType.Video &&
@@ -138,6 +138,6 @@ internal static class Downloader
             args.Add("""-o "%(playlist)s = %(playlist_autonumber)s - %(title)s [%(id)s].%(ext)s" --playlist-reverse""");
         }
 
-        return string.Join(" ", args.Concat(additionalArgs ?? Enumerable.Empty<string>()));
+        return string.Join(" ", args.Concat(additionalArgs ?? []));
     }
 }

--- a/CCVTAC/CCVTAC.Console/Downloading/Entities/DownloadEntityFactory.cs
+++ b/CCVTAC/CCVTAC.Console/Downloading/Entities/DownloadEntityFactory.cs
@@ -33,7 +33,7 @@ public static class DownloadEntityFactory
 
         if (typesWithResourceIds.IsEmpty())
         {
-            return Result.Fail("Unsupported or invalid URL. (No matching URL found.)");
+            return Result.Fail("Unsupported or invalid URL.");
         }
 
         (MediaDownloadType type, string resourceId, string? supplementaryResourceId) =

--- a/CCVTAC/CCVTAC.Console/Help.cs
+++ b/CCVTAC/CCVTAC.Console/Help.cs
@@ -4,27 +4,71 @@ public static class Help
 {
     internal static void Print(Printer printer)
     {
-        printer.Print("CodeConscious Video-to-Audio Converter (CCVTAC)");
-        printer.Print("• Easily convert YouTube videos to local M4A audio files with ID3v2 tags!");
-        printer.Print("• Supports video, playlist, and channel URLs");
-        printer.Print("• Video metadata (uploader name and URL, source URL, etc.) saved to Comment tags");
-        printer.Print("• Auto-renames files via specific regex patterns (to remove media IDs, etc.)");
-        printer.Print("• Video thumbnails are auto-trimmed and written to files as album art (Optional)");
-        printer.Print("• Post-processed files are automatically moved to a specified directory");
-        printer.Print("• All URLs entered are saved locally to a file specified in the settings",
-                      appendLines: 1);
+        string helpText = """"
+        CCVTAC (CodeConscious Video-to-Audio Converter) is a small .NET-powered CLI
+        tool that acts as a wrapper around yt-dlp (https://github.com/yt-dlp/yt-dlp)
+        to enable easier downloads of M4A audio from YouTube videos, playlist, and
+        channels, plus do some automatic post-processing (tagging, renaming, and
+        moving) as well.
 
-        printer.Print("Prerequisites:");
-        printer.Print("• [Required] yt-dlp (https://github.com/yt-dlp/yt-dlp/) for downloading audio");
-        printer.Print("• [Optional] mogrify (https://imagemagick.org/script/mogrify.php) for auto-cropping album art",
-                      appendLines: 1);
+        Feel free to use it yourself, but please do so responsibly. No warranties or
+        guarantees provided!
 
-        printer.Print("Instructions:");
-        printer.Print("• Run the program once to generate a blank settings.json file, then populate it with directory paths.");
-        printer.Print("• After the application starts, enter single video or playlist URLs to start the download process.");
-        printer.Print("• Enter \"q\" or \"quit\" to quit.");
-        printer.Print("• Pass \"--history\" to display recent URL history.", appendLines: 1);
+        RUNNING IT
 
-        printer.Print("Please help improve this tool by reporting errors (with any entered URLs) at https://github.com/codeconscious/ccvtac/issues.");
+        Prerequisites:
+
+        • .NET 8 runtime https://dotnet.microsoft.com/en-us/download/dotnet/8.0
+        • A valid settings file (see below)
+        • yt-dlp https://github.com/yt-dlp/yt-dlp
+        • Optional: mogrify https://imagemagick.org/script/mogrify.php (for auto-
+        trimming album art)
+
+        Settings:
+
+        A valid settings file is mandatory to use this application.
+
+        The application will look for a file named `settings.json` in its directory.
+        However, you can manually specify an existing file path using the `-s`
+        option, such as `dotnet run -- -s <PATH_TO_YOUR_FILE>`.
+
+        If your `settings.json` file does not exist, one will be created in the
+        application directory with default settings. At minimum, you will need to
+        enter (1) an existing directory for temporary working files, (2) an existing
+        directory to which the final audio files should be moved, and (3) a path to
+        your history file. The other settings have sensible defaults.
+
+        I added the `sleepBetweenDownloadsSeconds` and `sleepBetweenBatchesSeconds`
+        settings to help reduce concentrated loads on YouTube servers. Please avoid
+        lowering these values too much and slamming their servers with enormous,
+        long-running downloads (even if their servers can take it).
+
+        Using the application:
+
+        Once your settings are ready, run the application with `dotnet run`.
+        Optionally, pass `-h` or `--help` for instructions (e.g., `dotnet run -- --help`).
+
+        When the application is running, simply enter at least one YouTube media URL
+        (video, playlist, or channel) at the prompt and press the Enter key.
+        Separate multiple URLs by spaces.
+
+        Enter `quit` or `q` to quit.
+
+        Entering `history` will display your recent URL history.
+
+        Upgrading yt-dlp:
+
+        Periodically ensure you are running the latest version of yt-dlp, especially
+        if you start experiencing download errors. See the yt-dlp GitHub page
+        https://github.com/yt-dlp/yt-dlp#update for more. (Likely commands are `sudo
+        yt-dlp -U` or `pip install --upgrade yt-dlp`.)
+
+        Reporting issues:
+
+        If you run into any issues, please create an issue on GitHub with as much
+        information as possible. Thank you!
+        """";
+
+        printer.Print(helpText, processMarkup: false);
     }
 }

--- a/CCVTAC/CCVTAC.Console/PostProcessing/Deleter.cs
+++ b/CCVTAC/CCVTAC.Console/PostProcessing/Deleter.cs
@@ -4,7 +4,7 @@ namespace CCVTAC.Console.PostProcessing;
 
 internal static class Deleter
 {
-    public static void Run(string workingDirectory, Printer printer)
+    public static void Run(string workingDirectory, bool verbose, Printer printer)
     {
         DirectoryInfo dir = new(workingDirectory);
         List<string> deletableExtensions = [".json", ".jpg"];
@@ -17,7 +17,9 @@ internal static class Deleter
             try
             {
                 file.Delete();
-                printer.Print($"• Deleted \"{file.Name}\"");
+
+                if (verbose)
+                    printer.Print($"• Deleted \"{file.Name}\"");
             }
             catch (Exception ex)
             {

--- a/CCVTAC/CCVTAC.Console/PostProcessing/Mover.cs
+++ b/CCVTAC/CCVTAC.Console/PostProcessing/Mover.cs
@@ -1,15 +1,15 @@
 ﻿using System.IO;
 using System.Text.Json;
 using CCVTAC.Console.PostProcessing.Tagging;
+using CCVTAC.Console.Settings;
 
 namespace CCVTAC.Console.PostProcessing;
 
 internal static class Mover
 {
-    internal static void Run(string workingDirectory,
-                             string moveToDirectory,
-                             IEnumerable<TaggingSet> taggingSets,
+    internal static void Run(IEnumerable<TaggingSet> taggingSets,
                              CollectionMetadata? maybeCollectionData,
+                             UserSettings userSettings,
                              bool shouldOverwrite,
                              Printer printer)
     {
@@ -17,10 +17,11 @@ internal static class Mover
 
         uint successCount = 0;
         uint failureCount = 0;
-        DirectoryInfo workingDirInfo = new(workingDirectory);
+        bool isVerbose = userSettings.VerboseOutput;
+        DirectoryInfo workingDirInfo = new(userSettings.WorkingDirectory);
 
         string subFolderName = GetDefaultFolderName(maybeCollectionData, taggingSets.First(), workingDirInfo);
-        string moveToDir = Path.Combine(moveToDirectory, subFolderName);
+        string moveToDir = Path.Combine(userSettings.MoveToDirectory, subFolderName);
 
         try
         {
@@ -48,7 +49,9 @@ internal static class Mover
                     $"{Path.Combine(moveToDir, file.Name)}",
                     shouldOverwrite);
                 successCount++;
-                printer.Print($"• Moved \"{file.Name}\"");
+
+                if (isVerbose)
+                    printer.Print($"• Moved \"{file.Name}\"");
             }
             catch (Exception ex)
             {

--- a/CCVTAC/CCVTAC.Console/PostProcessing/PostProcessing.cs
+++ b/CCVTAC/CCVTAC.Console/PostProcessing/PostProcessing.cs
@@ -45,9 +45,9 @@ public sealed class Setup(UserSettings userSettings, Printer printer)
             Printer.Print(tagResult.Value);
 
             // AudioNormalizer.Run(UserSettings.WorkingDirectory, Printer); // TODO: `mp3gain`は無理なので、別のnormalize方法を要検討。
-            Renamer.Run(UserSettings.WorkingDirectory, Printer);
-            Mover.Run(UserSettings.WorkingDirectory, UserSettings.MoveToDirectory, taggingSets, collectionJson, true, Printer);
-            Deleter.Run(UserSettings.WorkingDirectory, Printer);
+            Renamer.Run(UserSettings.WorkingDirectory, UserSettings.VerboseOutput, Printer);
+            Mover.Run(taggingSets, collectionJson, UserSettings, true, Printer);
+            Deleter.Run(UserSettings.WorkingDirectory, UserSettings.VerboseOutput, Printer);
         }
         else
         {

--- a/CCVTAC/CCVTAC.Console/PostProcessing/PostProcessing.cs
+++ b/CCVTAC/CCVTAC.Console/PostProcessing/PostProcessing.cs
@@ -13,6 +13,12 @@ public sealed class Setup(UserSettings userSettings, Printer printer)
 
     internal void Run()
     {
+        if (UserSettings.PauseBeforePostProcessing)
+        {
+            Printer.Warning("Paused before post processing. Press the Enter key to continue.");
+            System.Console.ReadLine();
+        }
+
         Watch watch = new();
 
         Printer.Print("Starting post-processing...");

--- a/CCVTAC/CCVTAC.Console/PostProcessing/Renamer.cs
+++ b/CCVTAC/CCVTAC.Console/PostProcessing/Renamer.cs
@@ -38,6 +38,10 @@ internal static class Renamer
             "%<1>s - %<2>s",
             "PERSON - TRACK"),
         new(
+            new Regex("""(.+?) - (.+?) ℗ ([\d\?？]{4})"""),
+            "%<1>s - %<2>s [%<3>s]",
+            "PERSON - TRACK ℗ YEAR"),
+        new(
             new Regex(@"(.+?)(?: - )(.+?) \[[\w⧸]+\] .+ \(([\d\?？]{4})\)"),
             "%<1>s - %<2>s [%<3>s]",
             "PERSON - TRACK [YEAR]"),

--- a/CCVTAC/CCVTAC.Console/PostProcessing/Renamer.cs
+++ b/CCVTAC/CCVTAC.Console/PostProcessing/Renamer.cs
@@ -84,7 +84,7 @@ internal static class Renamer
             "Replace en dashes with hyphens")
     };
 
-    public static void Run(string workingDirectory, Printer printer)
+    public static void Run(string workingDirectory, bool isVerbose, Printer printer)
     {
         Watch watch = new();
 
@@ -142,8 +142,12 @@ internal static class Renamer
                 File.Move(
                     filePath.FullName,
                     Path.Combine(workingDirectory, newFileName));
-                printer.Print($"• From: \"{filePath.Name}\"");
-                printer.Print($"    To: \"{newFileName}\"");
+
+                if (isVerbose)
+                {
+                    printer.Print($"• From: \"{filePath.Name}\"");
+                    printer.Print($"    To: \"{newFileName}\"");
+                }
             }
             catch (Exception ex)
             {

--- a/CCVTAC/CCVTAC.Console/PostProcessing/Tagging/Tagger.cs
+++ b/CCVTAC/CCVTAC.Console/PostProcessing/Tagging/Tagger.cs
@@ -35,7 +35,9 @@ internal static class Tagger
         var parsedJsonResult = GetParsedVideoJson(taggingSet);
         if (parsedJsonResult.IsFailed)
         {
-            printer.Errors(parsedJsonResult);
+            printer.Errors(
+                $"Error deserializing video metadata from \"{taggingSet.JsonFilePath}\":",
+                parsedJsonResult);
             return;
         }
 
@@ -163,7 +165,7 @@ internal static class Tagger
         }
         catch (JsonException ex)
         {
-            return Result.Fail($"Error deserializing JSON from file \"{taggingSet.JsonFilePath}\": {ex.Message}");
+            return Result.Fail($"{ex.Message}{Environment.NewLine}{ex.StackTrace}");
         }
     }
 

--- a/CCVTAC/CCVTAC.Console/PostProcessing/Tagging/TaggingSet.cs
+++ b/CCVTAC/CCVTAC.Console/PostProcessing/Tagging/TaggingSet.cs
@@ -13,12 +13,13 @@ namespace CCVTAC.Console.PostProcessing.Tagging;
 internal readonly record struct TaggingSet
 {
     /// <summary>
-    /// The ID of a single video and perhaps its child video (if "split chapters" was used).
+    /// The ID of a single video and perhaps its child videos (if "split chapters" was used).
+    /// Used to locate all of the related files (whose filenames will contain the same ID).
     /// </summary>
     internal string ResourceId { get; init; }
 
     /// <summary>
-    /// All audio files for the associated resource ID. Several indicate
+    /// All audio files for the associated resource ID. Several files with identical IDs indicates
     /// that the original video was split into several audio files.
     /// </summary>
     internal ImmutableHashSet<string> AudioFilePaths { get; init; }
@@ -61,12 +62,12 @@ internal readonly record struct TaggingSet
     }
 
     /// <summary>
-    /// Create a collection of TaggingSets from a collection of filePaths
-    /// related to several video IDs.
+    ///     Create a collection of TaggingSets from a collection of filePaths
+    ///     related to several video IDs.
     /// </summary>
     /// <param name="filePaths">
-    /// A collection of file paths. Expected to contain 1 JSON file and
-    /// 1 image file for each unique video ID.
+    ///     A collection of file paths. Expected to contain all related audio files (>=1),
+    ///     1 JSON file, and 1 image file for each distinct video ID.
     /// </param>
     internal static ImmutableList<TaggingSet> CreateSets(IEnumerable<string> filePaths)
     {

--- a/CCVTAC/CCVTAC.Console/PostProcessing/Tagging/TaggingSet.cs
+++ b/CCVTAC/CCVTAC.Console/PostProcessing/Tagging/TaggingSet.cs
@@ -39,10 +39,11 @@ internal readonly record struct TaggingSet
     /// </summary>
     internal static Regex FileNamesWithVideoIdsRegex = new(@".+\[([\w_\-]{11})\](?:.*)?\.(\w+)");
 
-    internal TaggingSet(string              resourceId,
-                        IEnumerable<string> audioFilePaths,
-                        string              jsonFilePath,
-                        string              imageFilePath)
+    internal TaggingSet(
+        string resourceId,
+        IEnumerable<string> audioFilePaths,
+        string jsonFilePath,
+        string imageFilePath)
     {
         if (string.IsNullOrWhiteSpace(resourceId))
             throw new ArgumentException("The resource ID must be provided.");

--- a/CCVTAC/CCVTAC.Console/PostProcessing/VideoMetadata.cs
+++ b/CCVTAC/CCVTAC.Console/PostProcessing/VideoMetadata.cs
@@ -22,12 +22,15 @@ public readonly record struct VideoMetadata(
     [property: JsonPropertyName("tags")] IReadOnlyList<string> Tags,
     [property: JsonPropertyName("playable_in_embed")] bool? PlayableInEmbed,
     [property: JsonPropertyName("live_status")] string LiveStatus,
+    [property: JsonPropertyName("release_timestamp")] int? ReleaseTimestamp,
+    [property: JsonPropertyName("_format_sort_fields")] IReadOnlyList<string> FormatSortFields,
     [property: JsonPropertyName("automatic_captions")] AutomaticCaptions AutomaticCaptions,
     [property: JsonPropertyName("subtitles")] Subtitles Subtitles,
     [property: JsonPropertyName("album")] string Album,
     [property: JsonPropertyName("artist")] string Artist,
     [property: JsonPropertyName("track")] string Track,
-    [property: JsonPropertyName("release_year")] uint? ReleaseYear,
+    [property: JsonPropertyName("comment_count")] int? CommentCount,
+    [property: JsonPropertyName("chapters")] IReadOnlyList<Chapter> Chapters,
     [property: JsonPropertyName("like_count")] int? LikeCount,
     [property: JsonPropertyName("channel")] string Channel,
     [property: JsonPropertyName("channel_follower_count")] int? ChannelFollowerCount,
@@ -52,6 +55,8 @@ public readonly record struct VideoMetadata(
     [property: JsonPropertyName("display_id")] string DisplayId,
     [property: JsonPropertyName("fulltitle")] string Fulltitle,
     [property: JsonPropertyName("duration_string")] string DurationString,
+    [property: JsonPropertyName("release_date")] string ReleaseDate,
+    [property: JsonPropertyName("release_year")] uint? ReleaseYear,
     [property: JsonPropertyName("is_live")] bool? IsLive,
     [property: JsonPropertyName("was_live")] bool? WasLive,
     [property: JsonPropertyName("epoch")] int? Epoch,
@@ -127,10 +132,10 @@ public readonly record struct FormatInfo(
     [property: JsonPropertyName("format")] string Format,
     [property: JsonPropertyName("manifest_url")] string ManifestUrl,
     [property: JsonPropertyName("quality")] double? Quality,
-    [property: JsonPropertyName("has_drm")] object HasDrm,
+    [property: JsonPropertyName("has_drm")] bool? HasDrm,
     [property: JsonPropertyName("source_preference")] int? SourcePreference,
     [property: JsonPropertyName("asr")] int? Asr,
-    [property: JsonPropertyName("filesize")] int? Filesize,
+    [property: JsonPropertyName("filesize")] long? Filesize,
     [property: JsonPropertyName("audio_channels")] int? AudioChannels,
     [property: JsonPropertyName("tbr")] double? Tbr,
     [property: JsonPropertyName("language_preference")] int? LanguagePreference,
@@ -138,7 +143,7 @@ public readonly record struct FormatInfo(
     [property: JsonPropertyName("downloader_options")] DownloaderOptions DownloaderOptions,
     [property: JsonPropertyName("preference")] int? Preference,
     [property: JsonPropertyName("dynamic_range")] string DynamicRange,
-    [property: JsonPropertyName("filesize_approx")] int? FilesizeApprox
+    [property: JsonPropertyName("filesize_approx")] long? FilesizeApprox
 );
 
 public readonly record struct Fragment(
@@ -160,7 +165,15 @@ public readonly record struct HttpHeaders(
 );
 
 public readonly record struct Subtitles(
-    [property: JsonPropertyName("en-nP7-2PuUl7o")] IReadOnlyList<EnNP72PuUl7o> EnNP72PuUl7o
+    [property: JsonPropertyName("en-nP7-2PuUl7o")] IReadOnlyList<EnNP72PuUl7o> EnNP72PuUl7o,
+    [property: JsonPropertyName("live_chat")] IReadOnlyList<LiveChat> LiveChat
+);
+
+public record LiveChat(
+    [property: JsonPropertyName("url")] string Url,
+    [property: JsonPropertyName("video_id")] string VideoId,
+    [property: JsonPropertyName("ext")] string Ext,
+    [property: JsonPropertyName("protocol")] string Protocol
 );
 
 public readonly record struct Thumbnail(
@@ -176,4 +189,10 @@ public readonly record struct VersionInfo(
     [property: JsonPropertyName("version")] string Version,
     [property: JsonPropertyName("release_git_head")] string ReleaseGitHead,
     [property: JsonPropertyName("repository")] string Repository
+);
+
+public record Chapter(
+    [property: JsonPropertyName("start_time")] double? StartTime,
+    [property: JsonPropertyName("title")] string Title,
+    [property: JsonPropertyName("end_time")] double? EndTime
 );

--- a/CCVTAC/CCVTAC.Console/Printer.cs
+++ b/CCVTAC/CCVTAC.Console/Printer.cs
@@ -19,7 +19,7 @@ public sealed class Printer
         if (processMarkup)
             AnsiConsole.Markup(message);
         else
-            AnsiConsole.Write(message);
+            AnsiConsole.Write(message.EscapeMarkup());
 
         if (appendLineBreak)
             AnsiConsole.WriteLine();

--- a/CCVTAC/CCVTAC.Console/Printer.cs
+++ b/CCVTAC/CCVTAC.Console/Printer.cs
@@ -51,7 +51,7 @@ public sealed class Printer
     {
         if (headerMessage is not null)
         {
-            Print("[red]" + headerMessage + "[/]",
+            Print("[red]" + headerMessage.EscapeMarkup() + "[/]",
                   appendLines: appendLines,
                   processMarkup: true);
         }

--- a/CCVTAC/CCVTAC.Console/Program.cs
+++ b/CCVTAC/CCVTAC.Console/Program.cs
@@ -48,7 +48,8 @@ internal static class Program
         // Catch the user's pressing Ctrl-C (SIGINT).
         System.Console.CancelKeyPress += delegate
         {
-            printer.Warning("\nQuitting at user's request.");
+            printer.Warning("\nQuitting at user's request. You might want to verify and delete the files in the working directory.");
+            printer.Warning($"Working directory: {userSettings.WorkingDirectory}");
         };
 
         // Top-level `try` block to catch and pretty-print unexpected exceptions.

--- a/CCVTAC/CCVTAC.Console/Program.cs
+++ b/CCVTAC/CCVTAC.Console/Program.cs
@@ -83,7 +83,7 @@ internal static class Program
         var tempFiles = IoUtilties.Directories.GetDirectoryFiles(userSettings.WorkingDirectory);
         if (tempFiles.Any())
         {
-            printer.Error($"{tempFiles.Count} file(s) unexpectedly found in the working directory, so will abort:");
+            printer.Error($"{tempFiles.Count} file(s) unexpectedly found in the working directory ({userSettings.WorkingDirectory}), so will abort:");
             tempFiles.ForEach(file => printer.Warning($"• {file}"));
             return;
         }
@@ -152,7 +152,7 @@ internal static class Program
             var tempFiles = IoUtilties.Directories.GetDirectoryFiles(userSettings.WorkingDirectory);
             if (tempFiles.Any())
             {
-                printer.Error($"{tempFiles.Count} file(s) unexpectedly found in the working directory, so will abort:");
+                printer.Error($"{tempFiles.Count} file(s) unexpectedly found in the working directory ({userSettings.WorkingDirectory}), so will abort:");
                 tempFiles.ForEach(file => printer.Warning($"• {file}"));
                 return NextAction.QuitDueToErrors;
             }

--- a/CCVTAC/CCVTAC.Console/Settings/SettingsService.cs
+++ b/CCVTAC/CCVTAC.Console/Settings/SettingsService.cs
@@ -184,8 +184,10 @@ public class SettingsService(string? customFilePath = null)
                     { "History log file", $"{settings.HistoryFilePath} ({historyFileNote})" },
                 }
             .ToImmutableList();
-
         settingPairs.ForEach(pair => table.AddRow(pair.Key, pair.Value));
+
+        if (settings.PauseBeforePostProcessing)
+            table.AddRow("Pause before post-processing", "ON");
 
         printer.Print(table);
 

--- a/CCVTAC/CCVTAC.Console/Settings/SettingsService.cs
+++ b/CCVTAC/CCVTAC.Console/Settings/SettingsService.cs
@@ -4,13 +4,17 @@ using Spectre.Console;
 
 namespace CCVTAC.Console.Settings;
 
-public class SettingsService(string? customFilePath = null)
+public class SettingsService
 {
     private const string _defaultSettingsFileName = "settings.json";
-    internal string FullPath { get; init; } = customFilePath
-                                              ?? Path.Combine(
-                                                    AppContext.BaseDirectory,
-                                                    _defaultSettingsFileName);
+
+    private string FullPath { get; init; }
+
+    public SettingsService(string? customFilePath = null)
+    {
+        FullPath = customFilePath
+                   ?? Path.Combine(AppContext.BaseDirectory, _defaultSettingsFileName);
+    }
 
     public Result<UserSettings> PrepareUserSettings()
     {

--- a/CCVTAC/CCVTAC.Console/Settings/SettingsService.cs
+++ b/CCVTAC/CCVTAC.Console/Settings/SettingsService.cs
@@ -30,10 +30,10 @@ public class SettingsService(string? customFilePath = null)
 
         // Using `Fail` to indicate that the program cannot continue as is, though the write operation was successful.
         return Result.Fail(
-            $"A new empty settings file was created at \"{FullPath}\"." +
+            $"A new empty settings file was created at \"{FullPath}\"." + Environment.NewLine +
             """
             Please review it and populate it with your desired settings.
-            In particular, "workingDirectory," "moveToDirectory," and "historyFilePath" must be populated.
+            In particular, "workingDirectory," "moveToDirectory," and "historyFilePath" must be populated with valid paths.
             """);
     }
 

--- a/CCVTAC/CCVTAC.Console/Settings/SettingsService.cs
+++ b/CCVTAC/CCVTAC.Console/Settings/SettingsService.cs
@@ -178,6 +178,7 @@ public class SettingsService(string? customFilePath = null)
                         $"Ignore-upload-year channels",
                         $"{settings.IgnoreUploadYearUploaders?.Length.ToString() ?? "No"} {PluralizeIfNeeded("channel", settings.IgnoreUploadYearUploaders?.Length ?? 0)}"
                     },
+                    { "Verbose mode", settings.VerboseOutput ? "ON" : "OFF" },
                     { "Working directory", settings.WorkingDirectory },
                     { "Move-to directory", settings.MoveToDirectory },
                     { "History log file", $"{settings.HistoryFilePath} ({historyFileNote})" },

--- a/CCVTAC/CCVTAC.Console/Settings/SettingsService.cs
+++ b/CCVTAC/CCVTAC.Console/Settings/SettingsService.cs
@@ -33,6 +33,7 @@ public class SettingsService
         }
 
         // Using `Fail` to indicate that the program cannot continue as is, though the write operation was successful.
+        // I'd like to fix this. (It's probably a good use case for a discrimated union (after C# gets them).
         return Result.Fail(
             $"A new empty settings file was created at \"{FullPath}\"." + Environment.NewLine +
             """

--- a/CCVTAC/CCVTAC.Console/Settings/UserSettings.cs
+++ b/CCVTAC/CCVTAC.Console/Settings/UserSettings.cs
@@ -60,7 +60,7 @@ public sealed class UserSettings
     /// passed to the download tool.
     /// </summary>
     [JsonPropertyName("sleepBetweenDownloadsSeconds")]
-    public ushort SleepSecondsBetweenDownloads { get; init; } = 3;
+    public ushort SleepSecondsBetweenDownloads { get; init; } = 5;
 
     /// <summary>
     /// How many seconds the program should sleep between multiple batches.

--- a/CCVTAC/CCVTAC.Console/Settings/UserSettings.cs
+++ b/CCVTAC/CCVTAC.Console/Settings/UserSettings.cs
@@ -77,10 +77,10 @@ public sealed class UserSettings
     public string[]? IgnoreUploadYearUploaders { get; init; }
 
     /// <summary>
-    /// Shows verbose output from the external downloader tool if true; otherwise, shows normal output.
+    /// Shows verbose output if true; otherwise, shows normal output.
     /// </summary>
-    [JsonPropertyName("verboseDownloaderOutput")]
-    public bool VerboseDownloaderOutput { get; init; } = false;
+    [JsonPropertyName("verboseOutput")]
+    public bool VerboseOutput { get; init; } = false;
 
     /// <summary>
     /// If the supplied video uploader is specified in the settings, returns the video's upload year.

--- a/CCVTAC/CCVTAC.Console/Settings/UserSettings.cs
+++ b/CCVTAC/CCVTAC.Console/Settings/UserSettings.cs
@@ -83,6 +83,13 @@ public sealed class UserSettings
     public bool VerboseOutput { get; init; } = false;
 
     /// <summary>
+    /// Pause before post-processing to allow examining the downloaded files first.
+    /// For debugging purposes. Press the Enter key to continue with post-processing.
+    /// </summary>
+    [JsonPropertyName("pauseBeforePostProcessing")]
+    public bool PauseBeforePostProcessing { get; init; } = false;
+
+    /// <summary>
     /// If the supplied video uploader is specified in the settings, returns the video's upload year.
     /// Otherwise, returns null.
     /// </summary>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CCVTAC
 
-CCVTAC (CodeConscious Video-to-Audio Converter) is a small .NET-powered CLI tool that acts as a wrapper around [yt-dlp](https://github.com/yt-dlp/yt-dlp) to enable even easier downloads of M4A audio from specific YouTube videos, playlist, and channels, plus do some automatic post-processing (tagging and moving) as well.
+CCVTAC (CodeConscious Video-to-Audio Converter) is a small .NET-powered CLI tool that acts as a wrapper around [yt-dlp](https://github.com/yt-dlp/yt-dlp) to enable easier downloads of M4A audio from YouTube videos, playlist, and channels, plus do some automatic post-processing (tagging, renaming, and moving) as well.
 
 <img width="1451" alt="Sample download" src="https://github.com/codeconscious/ccvtac/assets/50596087/40fd5c56-0c39-44c4-9f5e-bc6398337820">
 
@@ -15,15 +15,15 @@ Feel free to use it yourself, but please do so responsibly. No warranties or gua
   - Standard playlist (with the newest video at index 1)
   - Release playlist (in which the playlist index represents the album number)
   - Channel
-- Adds video metadata (channel name, channel URL, video URL, etc.) summary to Comment tags
 - Writes ID3 tags (artists, title, etc.) to files where possible (via metadata or regex-based detection)
-- Renames files via specified regex patterns (to remove resource IDs, etc.)
+- Adds limited video metadata (channel name, channel URL, video URL, etc.) summary to files' Comment tags
+- Auto-renames files via specified regex patterns (to remove resource IDs, etc.)
 - Optionally auto-trims and writes video thumbnails to files as album art (if [mogrify](https://imagemagick.org/script/mogrify.php) is installed)
-- Customize behavior via a user settings file
+- Customized behavior via a user settings file
   - Optionally split video chapters into separate files
   - Specify the working directory for temporary files
   - Specify an output directory for audio files
-  - List channels for whom video upload years should _not_ be added to the tags' Year field (Adding years is the default behavior)
+  - Specify channels for whom video upload years should _not_ be added to the tags' Year field (Adding the years is the default behavior)
   - Set sleep times between batches (multiple URLs entered at once) and individual video downloads
 - Saves entered URLs to a local history file
 
@@ -37,8 +37,10 @@ Prerequisites:
 
 Run the program with `dotnet run`. Optionally, pass `-h` or `--help` for the instructions.
 
-If your `settings.json` file does not exist, it will created in the application directory with default settings. At minimum, you will need to enter paths to two existing directories: (1) a working directory for temporary files, (2) the directory to which the final audio files should be moved, and (3) a path to a history file. The other settings are optional.
+If your `settings.json` file does not exist, it will created in the application directory with default settings. At minimum, you will need to enter (1) a directory for temporary working files, (2) a directory to which the final audio files should be moved, and (3) a path to your history file. The other settings are optional.
 
-Once the program is running, simply enter at least one YouTube media URL at the prompt and press Enter.
+Once the program is running, simply enter at least one YouTube media URL at the prompt and press the Enter key. Enter `quit` or `q` to quit. Entering `history` will show your recent URL history.
 
-Recommended: Periodically ensure you're running the latest version of yt-dlp using `sudo yt-dlp -U` (or whatever command is appropriate for your system—see the [yt-dlp GitHub page](https://github.com/yt-dlp/yt-dlp#update) for more), especially if you start experiencing download errors.
+*Recommended:* Periodically ensure you're running the latest version of yt-dlp, especially if you start experiencing download errors. See the [yt-dlp GitHub page](https://github.com/yt-dlp/yt-dlp#update) for more. (Likely commands are `sudo yt-dlp -U` or `pip install --upgrade yt-dlp`.)
+
+If you run into any issues, please create an issue on GitHub with as much information as possible.

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ Feel free to use it yourself, but please do so responsibly. No warranties or gua
 - Converts YouTube videos to local M4A audio files (via [yt-dlp](https://github.com/yt-dlp/yt-dlp))
 - Supports 5 kinds of downloads
   - Video
-  - Video on a playlist (Playlist metadata will be written to the comments)
+  - Video on a playlist
   - Standard playlist (with the newest video at index 1)
-  - Release playlist (in which the playlist index represents the album number)
+  - Release playlist (in which the playlist index represents the album track number)
   - Channel
 - Writes ID3 tags (artists, title, etc.) to files where possible (via metadata or regex-based detection)
-- Adds limited video metadata (channel name, channel URL, video URL, etc.) summary to files' Comment tags
+- Adds limited video metadata (channel name and URL, video URL, etc.) summary to files' Comment tags
 - Auto-renames files via specified regex patterns (to remove resource IDs, etc.)
 - Optionally auto-trims and writes video thumbnails to files as album art (if [mogrify](https://imagemagick.org/script/mogrify.php) is installed)
 - Customized behavior via a user settings file
@@ -29,7 +29,7 @@ Feel free to use it yourself, but please do so responsibly. No warranties or gua
 
 ## Running It
 
-Prerequisites:
+### Prerequisites
 
 - [.NET 8 runtime](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)
 - A valid settings file (see below)
@@ -42,27 +42,25 @@ A valid settings file is mandatory to use this application.
 
 The application will look for a file named `settings.json` in its directory. However, you can manually specify an existing file path using the `-s` option, such as `dotnet run -- -s <PATH_TO_YOUR_FILE>`.
 
-If your `settings.json` file does not exist, it will created in the application directory with default settings. At minimum, you will need to enter (1) a directory for temporary working files, (2) a directory to which the final audio files should be moved, and (3) a path to your history file. The other settings have sensible defaults.
+If your `settings.json` file does not exist, one will be created in the application directory with default settings. At minimum, you will need to enter (1) an existing directory for temporary working files, (2) an existing directory to which the final audio files should be moved, and (3) a path to your history file. The other settings have sensible defaults.
 
 Sample settings file:
 
 ```json
 {
-  "workingDirectory": "/Users/me/temp", // An existing directory for working files
-  "moveToDirectory": "/Users/me/Downloads", // An existing directory to which audio files will be saved
-  "historyFilePath": "/Users/me/Downloads/history.log", // An file to which your entered URLs are saved
-  "sleepBetweenDownloadsSeconds": 10, // The number of seconds between individual video downloads on playlists and channels
-  "sleepBetweenBatchesSeconds": 20, // The number of seconds between batches (i.e., URLs you enter)
+  "workingDirectory": "/Users/me/temp", // A temporary home for working files
+  "moveToDirectory": "/Users/me/Downloads", // Which audio files should be saved
+  "historyFilePath": "/Users/me/Downloads/history.log", // Logs your entered URLs
+  "sleepBetweenDownloadsSeconds": 10, // Delay between video downloads for playlists and channels
+  "sleepBetweenBatchesSeconds": 20, // Delay between batches (i.e., each URL entered)
   "splitChapters": true, // Should videos with chapters be split into separate files?
-  "historyDisplayCount": 20, // The number of history entries to show when `history` is entered
-  "verboseOutput": true,
-  "pauseBeforePostProcessing": false,
-  "ignoreUploadYearUploaders": [
-    "Channel Name",
-    "Another channel name"
+  "historyDisplayCount": 20, // Count of entries to show for `history`
+  "verboseOutput": true, // Use `false` for quiet mode
+  "ignoreUploadYearUploaders": [ // By default, the upload year of the video is
+    "Channel Name",              // saved to files' Year tag. However, this will
+    "Another channel name"       // not occur for videos on channels listed here.
   ]
 }
-
 ```
 
 I added the `sleepBetweenDownloadsSeconds` and `sleepBetweenBatchesSeconds` settings to help reduce concentrated loads on YouTube servers. Please avoid lowering these values too much and slamming their servers with enormous, long-running downloads (even if their servers can take it).
@@ -81,6 +79,6 @@ Entering `history` will display your recent URL history.
 
 Periodically ensure you are running the latest version of yt-dlp, especially if you start experiencing download errors. See the [yt-dlp GitHub page](https://github.com/yt-dlp/yt-dlp#update) for more. (Likely commands are `sudo yt-dlp -U` or `pip install --upgrade yt-dlp`.)
 
-### Getting help
+## Reporting issues
 
 If you run into any issues, please create an issue on GitHub with as much information as possible. Thank you!

--- a/README.md
+++ b/README.md
@@ -32,15 +32,55 @@ Feel free to use it yourself, but please do so responsibly. No warranties or gua
 Prerequisites:
 
 - [.NET 8 runtime](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)
+- A valid settings file (see below)
 - [yt-dlp](https://github.com/yt-dlp/yt-dlp)
 - Optional: [mogrify](https://imagemagick.org/script/mogrify.php) (for auto-trimming album art)
 
-Run the program with `dotnet run`. Optionally, pass `-h` or `--help` for the instructions.
+### Settings
 
-If your `settings.json` file does not exist, it will created in the application directory with default settings. At minimum, you will need to enter (1) a directory for temporary working files, (2) a directory to which the final audio files should be moved, and (3) a path to your history file. The other settings are optional.
+A valid settings file is mandatory to use this application.
 
-Once the program is running, simply enter at least one YouTube media URL at the prompt and press the Enter key. Enter `quit` or `q` to quit. Entering `history` will show your recent URL history.
+The application will look for a file named `settings.json` in its directory. However, you can manually specify an existing file path using the `-s` option, such as `dotnet run -- -s <PATH_TO_YOUR_FILE>`.
 
-*Recommended:* Periodically ensure you're running the latest version of yt-dlp, especially if you start experiencing download errors. See the [yt-dlp GitHub page](https://github.com/yt-dlp/yt-dlp#update) for more. (Likely commands are `sudo yt-dlp -U` or `pip install --upgrade yt-dlp`.)
+If your `settings.json` file does not exist, it will created in the application directory with default settings. At minimum, you will need to enter (1) a directory for temporary working files, (2) a directory to which the final audio files should be moved, and (3) a path to your history file. The other settings have sensible defaults.
 
-If you run into any issues, please create an issue on GitHub with as much information as possible.
+Sample settings file:
+
+```json
+{
+  "workingDirectory": "/Users/me/temp", // An existing directory for working files
+  "moveToDirectory": "/Users/me/Downloads", // An existing directory to which audio files will be saved
+  "historyFilePath": "/Users/me/Downloads/history.log", // An file to which your entered URLs are saved
+  "sleepBetweenDownloadsSeconds": 10, // The number of seconds between individual video downloads on playlists and channels
+  "sleepBetweenBatchesSeconds": 20, // The number of seconds between batches (i.e., URLs you enter)
+  "splitChapters": true, // Should videos with chapters be split into separate files?
+  "historyDisplayCount": 20, // The number of history entries to show when `history` is entered
+  "verboseOutput": true,
+  "pauseBeforePostProcessing": false,
+  "ignoreUploadYearUploaders": [
+    "Channel Name",
+    "Another channel name"
+  ]
+}
+
+```
+
+I added the `sleepBetweenDownloadsSeconds` and `sleepBetweenBatchesSeconds` settings to help reduce concentrated loads on YouTube servers. Please avoid lowering these values too much and slamming their servers with enormous, long-running downloads (even if their servers can take it).
+
+### Running the application
+
+Once your settings are ready, run the application with `dotnet run`. Optionally, pass `-h` or `--help` for instructions (e.g., `dotnet run -- --help`).
+
+When the application is running, simply enter at least one YouTube media URL (video, playlist, or channel) at the prompt and press the Enter key. Separate multiple URLs by spaces.
+
+Enter `quit` or `q` to quit.
+
+Entering `history` will display your recent URL history.
+
+## yt-dlp upgrades
+
+Periodically ensure you are running the latest version of yt-dlp, especially if you start experiencing download errors. See the [yt-dlp GitHub page](https://github.com/yt-dlp/yt-dlp#update) for more. (Likely commands are `sudo yt-dlp -U` or `pip install --upgrade yt-dlp`.)
+
+### Getting help
+
+If you run into any issues, please create an issue on GitHub with as much information as possible. Thank you!

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Sample settings file:
 
 I added the `sleepBetweenDownloadsSeconds` and `sleepBetweenBatchesSeconds` settings to help reduce concentrated loads on YouTube servers. Please avoid lowering these values too much and slamming their servers with enormous, long-running downloads (even if their servers can take it).
 
-### Running the application
+### Using the application
 
 Once your settings are ready, run the application with `dotnet run`. Optionally, pass `-h` or `--help` for instructions (e.g., `dotnet run -- --help`).
 
@@ -75,7 +75,7 @@ Enter `quit` or `q` to quit.
 
 Entering `history` will display your recent URL history.
 
-## yt-dlp upgrades
+## Upgrading yt-dlp
 
 Periodically ensure you are running the latest version of yt-dlp, especially if you start experiencing download errors. See the [yt-dlp GitHub page](https://github.com/yt-dlp/yt-dlp#update) for more. (Likely commands are `sudo yt-dlp -U` or `pip install --upgrade yt-dlp`.)
 

--- a/TODO.md
+++ b/TODO.md
@@ -6,6 +6,7 @@ Features that I might consider as features or improvements in the future. Not al
 - Stop downloading if there are repeated errors from yt-dlp
 - Logging levels (current/full vs. light)
 - Logging to a file
+- Clean up errors (e.g., add a summary header at the caller and remove from the `return`)
 - JSON history that stores more data than just URLs (Or maybe the log file would be sufficient? If so, is the history file even needed? Maybe allow up-and-down scrolling through history?)
 - yt-dlp can handle tabs on YouTube channels too, so look into supporting those
 - Changing, saving, and reloading of settings while running the program

--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,6 @@ Features that I might consider as features or improvements in the future. Not al
 
 - Add a post-processing–only option for already-downloaded temporary files (via aborted downloads, etc.)
 - Stop downloading if there are repeated errors from yt-dlp
-- Logging levels (current/full vs. light)
 - Logging to a file
 - Clean up errors (e.g., add a summary header at the caller and remove from the `return`)
 - JSON history that stores more data than just URLs (Or maybe the log file would be sufficient? If so, is the history file even needed? Maybe allow up-and-down scrolling through history?)


### PR DESCRIPTION
- Add a new verbosity setting for on-screen logging
    - When `true`, the logging is as it's always been
    - When `false`, some messages will be elided
- よくないかもだが、ついでに
  - Fix too-long filenames causing download errors
  - Various minor tweaks and comments
  - Includes #36 