### PR TITLE
Update `VideoMetadata` and add `pauseBeforePostProcessing` setting

### DIFF
--- a/CCVTAC/CCVTAC.Console/PostProcessing/PostProcessing.cs
+++ b/CCVTAC/CCVTAC.Console/PostProcessing/PostProcessing.cs
@@ -13,6 +13,12 @@ public sealed class Setup(UserSettings userSettings, Printer printer)
 
     internal void Run()
     {
+        if (UserSettings.PauseBeforePostProcessing)
+        {
+            Printer.Warning("Paused before post processing. Press the Enter key to continue.");
+            System.Console.ReadLine();
+        }
+
         Watch watch = new();
 
         Printer.Print("Starting post-processing...");

--- a/CCVTAC/CCVTAC.Console/PostProcessing/Tagging/Tagger.cs
+++ b/CCVTAC/CCVTAC.Console/PostProcessing/Tagging/Tagger.cs
@@ -163,6 +163,7 @@ internal static class Tagger
         }
         catch (JsonException ex)
         {
+            // TODO: Probably should return the exception.
             return Result.Fail($"Error deserializing JSON from file \"{taggingSet.JsonFilePath}\": {ex.Message}");
         }
     }

--- a/CCVTAC/CCVTAC.Console/PostProcessing/Tagging/Tagger.cs
+++ b/CCVTAC/CCVTAC.Console/PostProcessing/Tagging/Tagger.cs
@@ -163,8 +163,7 @@ internal static class Tagger
         }
         catch (JsonException ex)
         {
-            // TODO: Probably should return the exception.
-            return Result.Fail($"Error deserializing JSON from file \"{taggingSet.JsonFilePath}\": {ex.Message}");
+            return Result.Fail($"Error deserializing video JSON from file \"{taggingSet.JsonFilePath}\": {ex.Message}\n{ex.StackTrace}");
         }
     }
 

--- a/CCVTAC/CCVTAC.Console/PostProcessing/Tagging/Tagger.cs
+++ b/CCVTAC/CCVTAC.Console/PostProcessing/Tagging/Tagger.cs
@@ -35,7 +35,9 @@ internal static class Tagger
         var parsedJsonResult = GetParsedVideoJson(taggingSet);
         if (parsedJsonResult.IsFailed)
         {
-            printer.Errors(parsedJsonResult);
+            printer.Errors(
+                $"Error deserializing video metadata from \"{taggingSet.JsonFilePath}\":",
+                parsedJsonResult);
             return;
         }
 
@@ -163,7 +165,7 @@ internal static class Tagger
         }
         catch (JsonException ex)
         {
-            return Result.Fail($"Error deserializing video JSON from file \"{taggingSet.JsonFilePath}\": {ex.Message}\n{ex.StackTrace}");
+            return Result.Fail($"{ex.Message}{Environment.NewLine}{ex.StackTrace}");
         }
     }
 

--- a/CCVTAC/CCVTAC.Console/PostProcessing/Tagging/TaggingSet.cs
+++ b/CCVTAC/CCVTAC.Console/PostProcessing/Tagging/TaggingSet.cs
@@ -39,10 +39,11 @@ internal readonly record struct TaggingSet
     /// </summary>
     internal static Regex FileNamesWithVideoIdsRegex = new(@".+\[([\w_\-]{11})\](?:.*)?\.(\w+)");
 
-    internal TaggingSet(string              resourceId,
-                        IEnumerable<string> audioFilePaths,
-                        string              jsonFilePath,
-                        string              imageFilePath)
+    internal TaggingSet(
+        string resourceId,
+        IEnumerable<string> audioFilePaths,
+        string jsonFilePath,
+        string imageFilePath)
     {
         if (string.IsNullOrWhiteSpace(resourceId))
             throw new ArgumentException("The resource ID must be provided.");

--- a/CCVTAC/CCVTAC.Console/PostProcessing/VideoMetadata.cs
+++ b/CCVTAC/CCVTAC.Console/PostProcessing/VideoMetadata.cs
@@ -22,12 +22,15 @@ public readonly record struct VideoMetadata(
     [property: JsonPropertyName("tags")] IReadOnlyList<string> Tags,
     [property: JsonPropertyName("playable_in_embed")] bool? PlayableInEmbed,
     [property: JsonPropertyName("live_status")] string LiveStatus,
+    [property: JsonPropertyName("release_timestamp")] int? ReleaseTimestamp,
+    [property: JsonPropertyName("_format_sort_fields")] IReadOnlyList<string> FormatSortFields,
     [property: JsonPropertyName("automatic_captions")] AutomaticCaptions AutomaticCaptions,
     [property: JsonPropertyName("subtitles")] Subtitles Subtitles,
     [property: JsonPropertyName("album")] string Album,
     [property: JsonPropertyName("artist")] string Artist,
     [property: JsonPropertyName("track")] string Track,
-    [property: JsonPropertyName("release_year")] uint? ReleaseYear,
+    [property: JsonPropertyName("comment_count")] int? CommentCount,
+    [property: JsonPropertyName("chapters")] IReadOnlyList<Chapter> Chapters,
     [property: JsonPropertyName("like_count")] int? LikeCount,
     [property: JsonPropertyName("channel")] string Channel,
     [property: JsonPropertyName("channel_follower_count")] int? ChannelFollowerCount,
@@ -52,6 +55,8 @@ public readonly record struct VideoMetadata(
     [property: JsonPropertyName("display_id")] string DisplayId,
     [property: JsonPropertyName("fulltitle")] string Fulltitle,
     [property: JsonPropertyName("duration_string")] string DurationString,
+    [property: JsonPropertyName("release_date")] string ReleaseDate,
+    [property: JsonPropertyName("release_year")] uint? ReleaseYear,
     [property: JsonPropertyName("is_live")] bool? IsLive,
     [property: JsonPropertyName("was_live")] bool? WasLive,
     [property: JsonPropertyName("epoch")] int? Epoch,
@@ -127,10 +132,10 @@ public readonly record struct FormatInfo(
     [property: JsonPropertyName("format")] string Format,
     [property: JsonPropertyName("manifest_url")] string ManifestUrl,
     [property: JsonPropertyName("quality")] double? Quality,
-    [property: JsonPropertyName("has_drm")] object HasDrm,
+    [property: JsonPropertyName("has_drm")] bool? HasDrm,
     [property: JsonPropertyName("source_preference")] int? SourcePreference,
     [property: JsonPropertyName("asr")] int? Asr,
-    [property: JsonPropertyName("filesize")] int? Filesize,
+    [property: JsonPropertyName("filesize")] long? Filesize,
     [property: JsonPropertyName("audio_channels")] int? AudioChannels,
     [property: JsonPropertyName("tbr")] double? Tbr,
     [property: JsonPropertyName("language_preference")] int? LanguagePreference,
@@ -138,7 +143,7 @@ public readonly record struct FormatInfo(
     [property: JsonPropertyName("downloader_options")] DownloaderOptions DownloaderOptions,
     [property: JsonPropertyName("preference")] int? Preference,
     [property: JsonPropertyName("dynamic_range")] string DynamicRange,
-    [property: JsonPropertyName("filesize_approx")] int? FilesizeApprox
+    [property: JsonPropertyName("filesize_approx")] long? FilesizeApprox
 );
 
 public readonly record struct Fragment(
@@ -160,7 +165,15 @@ public readonly record struct HttpHeaders(
 );
 
 public readonly record struct Subtitles(
-    [property: JsonPropertyName("en-nP7-2PuUl7o")] IReadOnlyList<EnNP72PuUl7o> EnNP72PuUl7o
+    [property: JsonPropertyName("en-nP7-2PuUl7o")] IReadOnlyList<EnNP72PuUl7o> EnNP72PuUl7o,
+    [property: JsonPropertyName("live_chat")] IReadOnlyList<LiveChat> LiveChat
+);
+
+public record LiveChat(
+    [property: JsonPropertyName("url")] string Url,
+    [property: JsonPropertyName("video_id")] string VideoId,
+    [property: JsonPropertyName("ext")] string Ext,
+    [property: JsonPropertyName("protocol")] string Protocol
 );
 
 public readonly record struct Thumbnail(
@@ -176,4 +189,10 @@ public readonly record struct VersionInfo(
     [property: JsonPropertyName("version")] string Version,
     [property: JsonPropertyName("release_git_head")] string ReleaseGitHead,
     [property: JsonPropertyName("repository")] string Repository
+);
+
+public record Chapter(
+    [property: JsonPropertyName("start_time")] double? StartTime,
+    [property: JsonPropertyName("title")] string Title,
+    [property: JsonPropertyName("end_time")] double? EndTime
 );

--- a/CCVTAC/CCVTAC.Console/Printer.cs
+++ b/CCVTAC/CCVTAC.Console/Printer.cs
@@ -51,7 +51,7 @@ public sealed class Printer
     {
         if (headerMessage is not null)
         {
-            Print("[red]" + headerMessage + "[/]",
+            Print("[red]" + headerMessage.EscapeMarkup() + "[/]",
                   appendLines: appendLines,
                   processMarkup: true);
         }

--- a/CCVTAC/CCVTAC.Console/Program.cs
+++ b/CCVTAC/CCVTAC.Console/Program.cs
@@ -83,7 +83,7 @@ internal static class Program
         var tempFiles = IoUtilties.Directories.GetDirectoryFiles(userSettings.WorkingDirectory);
         if (tempFiles.Any())
         {
-            printer.Error($"{tempFiles.Count} file(s) unexpectedly found in the working directory, so will abort:");
+            printer.Error($"{tempFiles.Count} file(s) unexpectedly found in the working directory ({userSettings.WorkingDirectory}), so will abort:");
             tempFiles.ForEach(file => printer.Warning($"• {file}"));
             return;
         }
@@ -152,7 +152,7 @@ internal static class Program
             var tempFiles = IoUtilties.Directories.GetDirectoryFiles(userSettings.WorkingDirectory);
             if (tempFiles.Any())
             {
-                printer.Error($"{tempFiles.Count} file(s) unexpectedly found in the working directory, so will abort:");
+                printer.Error($"{tempFiles.Count} file(s) unexpectedly found in the working directory ({userSettings.WorkingDirectory}), so will abort:");
                 tempFiles.ForEach(file => printer.Warning($"• {file}"));
                 return NextAction.QuitDueToErrors;
             }

--- a/CCVTAC/CCVTAC.Console/Settings/SettingsService.cs
+++ b/CCVTAC/CCVTAC.Console/Settings/SettingsService.cs
@@ -184,8 +184,10 @@ public class SettingsService(string? customFilePath = null)
                     { "History log file", $"{settings.HistoryFilePath} ({historyFileNote})" },
                 }
             .ToImmutableList();
-
         settingPairs.ForEach(pair => table.AddRow(pair.Key, pair.Value));
+
+        if (settings.PauseBeforePostProcessing)
+            table.AddRow("Pause before post-processing", "ON");
 
         printer.Print(table);
 

--- a/CCVTAC/CCVTAC.Console/Settings/UserSettings.cs
+++ b/CCVTAC/CCVTAC.Console/Settings/UserSettings.cs
@@ -83,6 +83,13 @@ public sealed class UserSettings
     public bool VerboseOutput { get; init; } = false;
 
     /// <summary>
+    /// Pause before post-processing to allow examining the downloaded files first.
+    /// For debugging purposes. Press the Enter key to continue with post-processing.
+    /// </summary>
+    [JsonPropertyName("pauseBeforePostProcessing")]
+    public bool PauseBeforePostProcessing { get; init; } = false;
+
+    /// <summary>
     /// If the supplied video uploader is specified in the settings, returns the video's upload year.
     /// Otherwise, returns null.
     /// </summary>

--- a/TODO.md
+++ b/TODO.md
@@ -6,6 +6,7 @@ Features that I might consider as features or improvements in the future. Not al
 - Stop downloading if there are repeated errors from yt-dlp
 - Logging levels (current/full vs. light)
 - Logging to a file
+- Clean up errors (e.g., add a summary header at the caller and remove from the `return`)
 - JSON history that stores more data than just URLs (Or maybe the log file would be sufficient? If so, is the history file even needed? Maybe allow up-and-down scrolling through history?)
 - yt-dlp can handle tabs on YouTube channels too, so look into supporting those
 - Changing, saving, and reloading of settings while running the program


### PR DESCRIPTION
- Update `VideoMetadata` to resolve issues causing post-processing failures
- Add a new debug setting to pause the tool before post-processing begins (making it easier to review the just-downloaded temporary files)
- Other minor fixes 