### PR TITLE
Save images seperately when appropropriate

### DIFF
--- a/src/CCVTAC.Console/Downloading/Downloader.cs
+++ b/src/CCVTAC.Console/Downloading/Downloader.cs
@@ -33,7 +33,7 @@ internal static class Downloader
             return Result.Fail(mediaTypeOrError.ErrorValue);
         }
 
-        return mediaTypeOrError.ResultValue;
+        return Result.Ok(mediaTypeOrError.ResultValue);
     }
 
     internal static Result<string> Run(string url, MediaType mediaType, UserSettings settings, Printer printer)

--- a/src/CCVTAC.Console/Downloading/Downloader.cs
+++ b/src/CCVTAC.Console/Downloading/Downloader.cs
@@ -25,18 +25,20 @@ internal static class Downloader
         { 101, "Download cancelled by --max-downloads, etc." },
     };
 
-    internal static Result<string> Run(string url, UserSettings settings, Printer printer)
+    internal static Result<MediaType> GetMediaType(string url)
     {
-        Watch watch = new();
-
         var mediaTypeOrError = FSharp.Downloading.mediaTypeWithIds(url);
         if (mediaTypeOrError.IsError)
         {
             return Result.Fail(mediaTypeOrError.ErrorValue);
         }
 
-        var mediaType = mediaTypeOrError.ResultValue;
-        printer.Print($"{mediaType.GetType().Name} URL '{url}' detected.");
+        return mediaTypeOrError.ResultValue;
+    }
+
+    internal static Result<string> Run(string url, MediaType mediaType, UserSettings settings, Printer printer)
+    {
+        Watch watch = new();
 
         var urls = FSharp.Downloading.downloadUrls(mediaType);
 

--- a/src/CCVTAC.Console/PostProcessing/Mover.cs
+++ b/src/CCVTAC.Console/PostProcessing/Mover.cs
@@ -97,6 +97,8 @@ internal static class Mover
                 image.MoveTo(
                     Path.Combine(moveToDir, _coverImageFileName),
                     overwrite: false);
+
+                printer.Print("Moved cover image.");
             }
 
         }

--- a/src/CCVTAC.Console/PostProcessing/Mover.cs
+++ b/src/CCVTAC.Console/PostProcessing/Mover.cs
@@ -8,10 +8,11 @@ namespace CCVTAC.Console.PostProcessing;
 
 internal static class Mover
 {
+    private static readonly Regex _playlistImageRegex = new(@"\[[OP]L[\w\d_-]+\]");
+
     private static bool IsPlaylistImage(string fileName)
     {
-        var regex = new Regex(@"\[[OP]L[\w\d_-]+\]");
-        return regex.IsMatch(fileName);
+        return _playlistImageRegex.IsMatch(fileName);
     }
 
     private static FileInfo? GetCoverImage(DirectoryInfo workingDirInfo, int audioFileCount)

--- a/src/CCVTAC.Console/PostProcessing/Mover.cs
+++ b/src/CCVTAC.Console/PostProcessing/Mover.cs
@@ -8,7 +8,7 @@ namespace CCVTAC.Console.PostProcessing;
 
 internal static class Mover
 {
-    private static readonly Regex _playlistImageRegex = new(@"\[[OP]L[\w\d_-]+\]");
+    private static readonly Regex _playlistImageRegex = new(@"\[[OP]L[\w\d_-]+\]"); // TODO: Add channels.
 
     private static bool IsPlaylistImage(string fileName)
     {
@@ -46,8 +46,8 @@ internal static class Mover
         DirectoryInfo workingDirInfo = new(settings.WorkingDirectory);
 
         string subFolderName = GetDefaultDirectoryName(maybeCollectionData, taggingSets.First());
-        string maybePlaylistName = maybeCollectionData?.Title ?? string.Empty;
-        string moveToDir = Path.Combine(settings.MoveToDirectory, subFolderName, maybePlaylistName);
+        string maybeCollectionName = maybeCollectionData?.Title ?? string.Empty;
+        string moveToDir = Path.Combine(settings.MoveToDirectory, subFolderName, maybeCollectionName);
 
         try
         {
@@ -91,9 +91,9 @@ internal static class Mover
 
         try
         {
-            var baseFileName = string.IsNullOrWhiteSpace(maybePlaylistName)
+            var baseFileName = string.IsNullOrWhiteSpace(maybeCollectionName)
                 ? subFolderName
-                : $"{subFolderName} - {maybePlaylistName}";
+                : $"{subFolderName} - {maybeCollectionName}";
 
             if (GetCoverImage(workingDirInfo, audioFiles.Count) is FileInfo image)
             {

--- a/src/CCVTAC.Console/PostProcessing/Mover.cs
+++ b/src/CCVTAC.Console/PostProcessing/Mover.cs
@@ -8,6 +8,8 @@ namespace CCVTAC.Console.PostProcessing;
 
 internal static class Mover
 {
+    private static readonly string _coverImageFileName = "cover.jpg";
+
     private static bool IsPlaylistImage(string fileName)
     {
         var regex = new Regex(@"\[[OP]L[\w\d_-]+\]");
@@ -91,7 +93,9 @@ internal static class Mover
         {
             if (GetCoverImage(workingDirInfo, audioFiles.Count()) is FileInfo fileInfo)
             {
-                fileInfo.MoveTo(Path.Combine(moveToDir, "cover.jpg"), overwrite: false);
+                fileInfo.MoveTo(
+                    Path.Combine(moveToDir, _coverImageFileName),
+                    overwrite: false);
             }
 
         }

--- a/src/CCVTAC.Console/PostProcessing/Mover.cs
+++ b/src/CCVTAC.Console/PostProcessing/Mover.cs
@@ -47,12 +47,13 @@ internal static class Mover
             throw;
         }
 
-        var eligibleAudioFiles = workingDirInfo.EnumerateFiles("*.m4a");
-        var eligibleImages = workingDirInfo.EnumerateFiles("*.jpg").Where(f => IsPlaylistImage(f.FullName));
-        var allEligibleFiles = eligibleAudioFiles.Concat(eligibleImages);
-        printer.Print($"Moving {eligibleAudioFiles.Count()} audio file(s) and {eligibleImages.Count()} images to \"{moveToDir}\"...");
+        var audioFiles = workingDirInfo.EnumerateFiles("*.m4a");
+        var playlistImage = workingDirInfo.EnumerateFiles("*.jpg")
+                                          .Where(f => IsPlaylistImage(f.FullName));
+        var allFiles = audioFiles.Concat(playlistImage);
 
-        foreach (FileInfo file in allEligibleFiles)
+        printer.Print($"Moving {audioFiles.Count()} audio file(s) to \"{moveToDir}\"...");
+        foreach (FileInfo file in allFiles)
         {
             try
             {

--- a/src/CCVTAC.Console/PostProcessing/Mover.cs
+++ b/src/CCVTAC.Console/PostProcessing/Mover.cs
@@ -66,8 +66,8 @@ internal static class Mover
             throw;
         }
 
-        var audioFiles = workingDirInfo.EnumerateFiles("*.m4a");
-        printer.Print($"Moving {audioFiles.Count()} audio file(s) to \"{moveToDir}\"...");
+        var audioFiles = workingDirInfo.EnumerateFiles("*.m4a").ToList();
+        printer.Print($"Moving {audioFiles.Count} audio file(s) to \"{moveToDir}\"...");
 
         foreach (FileInfo file in audioFiles)
         {
@@ -77,6 +77,7 @@ internal static class Mover
                     file.FullName,
                     $"{Path.Combine(moveToDir, file.Name)}",
                     shouldOverwrite);
+
                 successCount++;
 
                 if (verbose)
@@ -91,9 +92,9 @@ internal static class Mover
 
         try
         {
-            if (GetCoverImage(workingDirInfo, audioFiles.Count()) is FileInfo fileInfo)
+            if (GetCoverImage(workingDirInfo, audioFiles.Count) is FileInfo image)
             {
-                fileInfo.MoveTo(
+                image.MoveTo(
                     Path.Combine(moveToDir, _coverImageFileName),
                     overwrite: false);
             }

--- a/src/CCVTAC.Console/PostProcessing/Mover.cs
+++ b/src/CCVTAC.Console/PostProcessing/Mover.cs
@@ -8,8 +8,6 @@ namespace CCVTAC.Console.PostProcessing;
 
 internal static class Mover
 {
-    private static readonly string _coverImageFileName = "cover.jpg";
-
     private static bool IsPlaylistImage(string fileName)
     {
         var regex = new Regex(@"\[[OP]L[\w\d_-]+\]");
@@ -47,8 +45,8 @@ internal static class Mover
         DirectoryInfo workingDirInfo = new(settings.WorkingDirectory);
 
         string subFolderName = GetDefaultDirectoryName(maybeCollectionData, taggingSets.First());
-        string collectionFolder = maybeCollectionData?.Title ?? string.Empty;
-        string moveToDir = Path.Combine(settings.MoveToDirectory, subFolderName, collectionFolder);
+        string maybePlaylistName = maybeCollectionData?.Title ?? string.Empty;
+        string moveToDir = Path.Combine(settings.MoveToDirectory, subFolderName, maybePlaylistName);
 
         try
         {
@@ -92,10 +90,14 @@ internal static class Mover
 
         try
         {
+            var baseFileName = string.IsNullOrWhiteSpace(maybePlaylistName)
+                ? subFolderName
+                : $"{subFolderName} - {maybePlaylistName}";
+
             if (GetCoverImage(workingDirInfo, audioFiles.Count) is FileInfo image)
             {
                 image.MoveTo(
-                    Path.Combine(moveToDir, _coverImageFileName),
+                    Path.Combine(moveToDir, $"{baseFileName.Trim()}.jpg"),
                     overwrite: false);
 
                 printer.Print("Moved cover image.");

--- a/src/CCVTAC.Console/PostProcessing/PostProcessing.cs
+++ b/src/CCVTAC.Console/PostProcessing/PostProcessing.cs
@@ -3,13 +3,22 @@ using System.Text.Json;
 using System.Text.RegularExpressions;
 using CCVTAC.Console.PostProcessing.Tagging;
 using UserSettings = CCVTAC.FSharp.Settings.UserSettings;
+using static CCVTAC.FSharp.Downloading;
 
 namespace CCVTAC.Console.PostProcessing;
 
-public sealed class Setup(UserSettings settings, Printer printer)
+public sealed class PostProcessing
 {
-    public UserSettings Settings { get; } = settings;
-    public Printer Printer { get; } = printer;
+    public UserSettings Settings { get; }
+    public Printer Printer { get; }
+    public MediaType MediaType { get; }
+
+    public PostProcessing(UserSettings settings, MediaType mediaType, Printer printer)
+    {
+        Settings = settings;
+        Printer = printer;
+        MediaType = mediaType;
+    }
 
     internal void Run()
     {
@@ -39,7 +48,7 @@ public sealed class Setup(UserSettings settings, Printer printer)
 
         ImageProcessor.Run(Settings.WorkingDirectory, Printer);
 
-        var tagResult = Tagger.Run(Settings, taggingSets, collectionJson, Printer);
+        var tagResult = Tagger.Run(Settings, taggingSets, collectionJson, MediaType, Printer);
         if (tagResult.IsSuccess)
         {
             Printer.Print(tagResult.Value);

--- a/src/CCVTAC.Console/PostProcessing/Tagging/Tagger.cs
+++ b/src/CCVTAC.Console/PostProcessing/Tagging/Tagger.cs
@@ -18,7 +18,8 @@ internal static class Tagger
 
         Watch watch = new();
 
-        bool embedImages = mediaType.IsVideo || mediaType.IsPlaylistVideo;
+        bool embedImages = settings.EmbedImages &&
+                           mediaType.IsVideo || mediaType.IsPlaylistVideo;
 
         foreach (TaggingSet taggingSet in taggingSets)
         {
@@ -150,14 +151,14 @@ internal static class Tagger
 
             taggedFile.Tag.Comment = videoData.GenerateComment(collectionData);
 
-            if (imageFilePath is null)
-            {
-                printer.Print("Skipping image embedding.");
-            }
-            else
+            if (settings.EmbedImages && imageFilePath is not null)
             {
                 printer.Print("Will embedded the image.");
                 WriteImage(taggedFile, imageFilePath, printer);
+            }
+            else
+            {
+                printer.Print("Skipping image embedding.");
             }
 
             taggedFile.Save();

--- a/src/CCVTAC.FSharp/Settings.fs
+++ b/src/CCVTAC.FSharp/Settings.fs
@@ -14,6 +14,7 @@ module Settings =
         [<JsonPropertyName("sleepSecondsBetweenDownloads")>] SleepSecondsBetweenDownloads: uint16
         [<JsonPropertyName("sleepSecondsBetweenBatches")>]   SleepSecondsBetweenBatches: uint16
         [<JsonPropertyName("verboseOutput")>]                VerboseOutput: bool
+        [<JsonPropertyName("embedImages")>]                  EmbedImages: bool
         [<JsonPropertyName("ignoreUploadYearUploaders")>]    IgnoreUploadYearUploaders: string array
     }
 
@@ -27,6 +28,7 @@ module Settings =
         [
             ("Split video chapters", if settings.SplitChapters then "ON" else "OFF")
             ("Verbose mode", if settings.VerboseOutput then "ON" else "OFF")
+            ("Embed images", if settings.EmbedImages then "ON" else "OFF")
             ("Sleep between batches", settings.SleepSecondsBetweenBatches |> int |> pluralize  "second")
             ("Sleep between downloads", settings.SleepSecondsBetweenDownloads |> int |> pluralize "second")
             ("Ignore-upload-year channels", settings.IgnoreUploadYearUploaders.Length |> pluralize "channel")
@@ -106,5 +108,6 @@ module Settings =
                   SleepSecondsBetweenDownloads = 10us
                   SleepSecondsBetweenBatches = 20us
                   VerboseOutput = true
+                  EmbedImages = true
                   IgnoreUploadYearUploaders = [||] }
             writeFile defaultSettings confirmedPath


### PR DESCRIPTION
What: For playlists or split videos, save a representative image file named after the artist and playlist/album name.

Why: This gives the user the option to delete embedded artwork and only use a single image for a directory of audio.
