### PR TITLE
Post-processing `TaggingSet` fix and other improvements

### DIFF
--- a/src/CCVTAC.Console/PostProcessing/Deleter.cs
+++ b/src/CCVTAC.Console/PostProcessing/Deleter.cs
@@ -4,37 +4,38 @@ namespace CCVTAC.Console.PostProcessing;
 
 internal static class Deleter
 {
-    public static void Run(string workingDirectory, bool verbose, Printer printer)
+    public static void Run(ICollection<string> filesToDelete, bool verbose, Printer printer)
     {
-        DirectoryInfo dir = new(workingDirectory);
         List<string> deletableExtensions = [".json", ".jpg"];
 
         if (verbose)
             printer.Print($"Deleting temporary {string.Join(" and ", deletableExtensions)} files...");
 
-        foreach (FileInfo file in dir.EnumerateFiles("*")
-                                     .Where(f => deletableExtensions.Contains(f.Extension)))
+        foreach (var fileName in filesToDelete)
         {
             try
             {
-                file.Delete();
+                File.Delete(fileName);
 
                 if (verbose)
-                    printer.Print($"• Deleted \"{file.Name}\"");
+                    printer.Print($"• Deleted \"{fileName}\"");
             }
             catch (Exception ex)
             {
-                printer.Error($"• Could not delete \"{file.Name}\": {ex.Message}");
+                printer.Error($"• Deletion error: {ex.Message}");
             }
         }
 
         printer.Print("Deleted temporary files.");
+    }
 
+    public static void CheckRemaining(string workingDirectory, Printer printer)
+    {
         var tempFiles = IoUtilties.Directories.GetDirectoryFiles(workingDirectory);
         if (tempFiles.Any())
         {
             printer.Warning($"{tempFiles.Count} file(s) unexpectedly remain in the working folder:");
-            tempFiles.ForEach(file => printer.Print($"• {file}"));
+            tempFiles.ForEach(file => printer.Warning($"• {file}"));
         }
     }
 }

--- a/src/CCVTAC.Console/PostProcessing/PostProcessing.cs
+++ b/src/CCVTAC.Console/PostProcessing/PostProcessing.cs
@@ -48,7 +48,10 @@ public sealed class PostProcessing
             collectionJson = collectionJsonResult.Value;
         }
 
-        ImageProcessor.Run(Settings.WorkingDirectory, Settings.VerboseOutput, Printer);
+        if (Settings.EmbedImages)
+        {
+            ImageProcessor.Run(Settings.WorkingDirectory, Settings.VerboseOutput, Printer);
+        }
 
         var tagResult = Tagger.Run(Settings, taggingSets, collectionJson, MediaType, Printer);
         if (tagResult.IsSuccess)
@@ -58,7 +61,10 @@ public sealed class PostProcessing
             // AudioNormalizer.Run(UserSettings.WorkingDirectory, Printer); // TODO: normalize方法を要検討。
             Renamer.Run(Settings.WorkingDirectory, Settings.VerboseOutput, Printer);
             Mover.Run(taggingSets, collectionJson, Settings, true, Printer);
-            Deleter.Run(Settings.WorkingDirectory, Settings.VerboseOutput, Printer);
+
+            var taggingSetFileNames = taggingSets.SelectMany(set => set.AllFiles).ToImmutableList();
+            Deleter.Run(taggingSetFileNames, Settings.VerboseOutput, Printer);
+            Deleter.CheckRemaining(Settings.WorkingDirectory, Printer);
         }
         else
         {


### PR DESCRIPTION
- Fixed: If the JSON and JPEG image of a single video is downloaded, but its audio is not, but the instantiation of _all_ `TaggingSet`s will fail
- If embedding images is disabled in the settings, then skip image processing
- Extract the empty-directory-verification check to outside the file-deletion method