### PR TITLE
Split combined input URLs

### DIFF
--- a/src/CCVTAC.Console.Tests/UrlParsingTests.cs
+++ b/src/CCVTAC.Console.Tests/UrlParsingTests.cs
@@ -1,0 +1,18 @@
+using System.Collections.Immutable;
+using CCVTAC.Console;
+
+namespace CCVTAC.Tests;
+
+public sealed class UrlParsingTests
+{
+    [Fact]
+    public void MultipleValidUrlsEntered_CorrectlyParsed()
+    {
+        ImmutableList<string> combined = ["https://youtu.be/5OpuZHsPBhQhttps://youtu.be/NT22EGxTuNw"];
+        ImmutableList<string> expected = ["https://youtu.be/5OpuZHsPBhQ", "https://youtu.be/NT22EGxTuNw"];
+        var actual = UrlHelper.SplitCombinedUrls(combined);
+        Assert.Equal(expected.Count, actual.Count);
+        Assert.Equal(expected[0], actual[0]);
+        Assert.Equal(expected[1], actual[1]);
+    }
+}

--- a/src/CCVTAC.Console.Tests/UrlParsingTests.cs
+++ b/src/CCVTAC.Console.Tests/UrlParsingTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Immutable;
+using System.Collections.Generic;
 using CCVTAC.Console;
 
 namespace CCVTAC.Tests;
@@ -8,8 +8,8 @@ public sealed class UrlParsingTests
     [Fact]
     public void MultipleValidUrlsEntered_CorrectlyParsed()
     {
-        ImmutableList<string> combined = ["https://youtu.be/5OpuZHsPBhQhttps://youtu.be/NT22EGxTuNw"];
-        ImmutableList<string> expected = ["https://youtu.be/5OpuZHsPBhQ", "https://youtu.be/NT22EGxTuNw"];
+        List<string> combined = ["https://youtu.be/5OpuZHsPBhQhttps://youtu.be/NT22EGxTuNw"];
+        List<string> expected = ["https://youtu.be/5OpuZHsPBhQ", "https://youtu.be/NT22EGxTuNw"];
         var actual = UrlHelper.SplitCombinedUrls(combined);
         Assert.Equal(expected.Count, actual.Count);
         Assert.Equal(expected[0], actual[0]);

--- a/src/CCVTAC.Console/Program.cs
+++ b/src/CCVTAC.Console/Program.cs
@@ -137,6 +137,11 @@ internal static class Program
                                  .Distinct()
                                  .ToImmutableList();
 
+        if (_quitCommands.Contains(inputUrls[0].ToLowerInvariant()))
+        {
+            return NextAction.QuitAtUserRequest;
+        }
+
         var checkedUrls = UrlHelper.SplitCombinedUrls(inputUrls);
 
         if (checkedUrls.Count > 1)
@@ -151,11 +156,6 @@ internal static class Program
 
         foreach (string url in checkedUrls)
         {
-            if (_quitCommands.Contains(url.ToLowerInvariant()))
-            {
-                return NextAction.QuitAtUserRequest;
-            }
-
             // Show the history if requested.
             if (_historyCommands.Contains(url.ToLowerInvariant()))
             {

--- a/src/CCVTAC.Console/Program.cs
+++ b/src/CCVTAC.Console/Program.cs
@@ -3,6 +3,7 @@ using CCVTAC.Console.Settings;
 using CCVTAC.Console.Downloading;
 using Spectre.Console;
 using UserSettings = CCVTAC.FSharp.Settings.UserSettings;
+using System.Text.RegularExpressions;
 
 namespace CCVTAC.Console;
 
@@ -131,22 +132,24 @@ internal static class Program
 
         Watch watch = new();
 
-        var batchUrls = userInput.Split(" ")
+        var inputUrls = userInput.Split(" ")
                                  .Where(i => i.HasText())
                                  .Distinct()
                                  .ToImmutableList();
 
-        if (batchUrls.Count > 1)
+        var checkedUrls = UrlHelper.SplitCombinedUrls(inputUrls);
+
+        if (checkedUrls.Count > 1)
         {
-            printer.Print($"Batch of {batchUrls.Count} URLs entered.");
-            batchUrls.ForEach(i => printer.Print($"• {i}"));
+            printer.Print($"Batch of {checkedUrls.Count} URLs entered.");
+            checkedUrls.ForEach(i => printer.Print($"• {i}"));
             printer.PrintEmptyLines(1);
         }
 
         nuint currentBatch = 0;
         bool haveProcessedAny = false;
 
-        foreach (string url in batchUrls)
+        foreach (string url in checkedUrls)
         {
             if (_quitCommands.Contains(url.ToLowerInvariant()))
             {
@@ -192,9 +195,9 @@ internal static class Program
                 haveProcessedAny = true;
             }
 
-            if (batchUrls.Count > 1)
+            if (checkedUrls.Count > 1)
             {
-                printer.Print($"Processing batch {++currentBatch} of {batchUrls.Count}...");
+                printer.Print($"Processing batch {++currentBatch} of {checkedUrls.Count}...");
             }
 
             Watch jobWatch = new();
@@ -202,7 +205,7 @@ internal static class Program
             var mediaTypeResult = Downloader.GetMediaType(url);
             if (mediaTypeResult.IsFailed)
             {
-                printer.Error($"Could not parsed URL: {mediaTypeResult.Errors.First().Message}");
+                printer.Error($"Error parsing URL {url}: {mediaTypeResult.Errors.First().Message}");
                 return NextAction.Continue;
             }
             var mediaType = mediaTypeResult.Value;
@@ -220,15 +223,15 @@ internal static class Program
             var postProcessor = new PostProcessing.PostProcessing(settings, mediaType, printer);
             postProcessor.Run();
 
-            string batchClause = batchUrls.Count > 1
-                ? $" (batch {currentBatch} of {batchUrls.Count})"
+            string batchClause = checkedUrls.Count > 1
+                ? $" (batch {currentBatch} of {checkedUrls.Count})"
                 : string.Empty;
             printer.Print($"Processed '{url}'{batchClause} in {jobWatch.ElapsedFriendly}.");
         }
 
-        if (batchUrls.Count > 1)
+        if (checkedUrls.Count > 1)
         {
-            printer.Print($"\nAll done with {batchUrls.Count} batches in {watch.ElapsedFriendly}.");
+            printer.Print($"\nAll done with {checkedUrls.Count} batches in {watch.ElapsedFriendly}.");
         }
 
         return NextAction.Continue;

--- a/src/CCVTAC.Console/Program.cs
+++ b/src/CCVTAC.Console/Program.cs
@@ -3,7 +3,6 @@ using CCVTAC.Console.Settings;
 using CCVTAC.Console.Downloading;
 using Spectre.Console;
 using UserSettings = CCVTAC.FSharp.Settings.UserSettings;
-using System.Text.RegularExpressions;
 
 namespace CCVTAC.Console;
 

--- a/src/CCVTAC.Console/UrlHelper.cs
+++ b/src/CCVTAC.Console/UrlHelper.cs
@@ -30,10 +30,10 @@ public static class UrlHelper
             var indexPairs =
                 startIndices
                     .Select((si, itemIndex) => {
-                            var end = itemIndex == 0 // The last URL entered by user.
+                            int endIndex = itemIndex == 0 // If the last URL entered by user.
                                 ? url.Length
                                 : startIndices[itemIndex-1];
-                            return new IndexPair(si, end);
+                            return new IndexPair(si, endIndex);
                         })
                     .ToImmutableList();
 

--- a/src/CCVTAC.Console/UrlHelper.cs
+++ b/src/CCVTAC.Console/UrlHelper.cs
@@ -1,0 +1,48 @@
+using System.Text.RegularExpressions;
+
+namespace CCVTAC.Console;
+
+public static class UrlHelper
+{
+    private static readonly Regex _httpsRegex = new("https:");
+
+    private record IndexPair(int Start, int End);
+
+    public static ImmutableList<string> SplitCombinedUrls(ICollection<string> urls)
+    {
+        List<string> safeUrls = new(urls.Count);
+
+        foreach (var url in urls)
+        {
+            var matches = _httpsRegex.Matches(url).OfType<Match>();
+
+            if (matches.Count() == 1)
+            {
+                safeUrls.Add(url);
+                continue;
+            }
+
+            var startIndices = matches
+                .Select(m => m.Index)
+                .Reverse()
+                .ToImmutableList();
+
+            var indexPairs =
+                startIndices
+                    .Select((si, itemIndex) => {
+                            var end = itemIndex == 0 // The last URL entered by user.
+                                ? url.Length
+                                : startIndices[itemIndex-1];
+                            return new IndexPair(si, end);
+                        })
+                    .ToImmutableList();
+
+            safeUrls.AddRange(
+                indexPairs
+                    .Select(p => url[p.Start..p.End])
+                    .Reverse());
+        }
+
+        return [.. safeUrls.Distinct()];
+    }
+}


### PR DESCRIPTION
Currently, if users accidentally paste in two or more URLs without spaces between them, the application will treat them as one long URL and fail to parse them correctly.

With these updates, if such a combined URL is found, it will be split into its constituent URLs. No more need for spaces!