### PR TITLE
Refactor working directory emptiness verification

### DIFF
--- a/src/CCVTAC.Console/IoUtilties/Directories.cs
+++ b/src/CCVTAC.Console/IoUtilties/Directories.cs
@@ -24,4 +24,36 @@ internal static class Directories
                                 dirFilePath.EndsWith(ignoreFile)))
                         .ToImmutableList();
     }
+
+    internal static Result CheckIfEmpty(string directory)
+    {
+        var files = GetDirectoryFiles(directory);
+
+        if (files.IsEmpty)
+        {
+            return Result.Ok();
+        }
+
+        var errors = files.Select(f => new Error(f));
+        return Result.Fail(errors);
+    }
+
+    internal static Result WarnIfAnyFiles(string directory, Printer printer)
+    {
+        var result = CheckIfEmpty(directory);
+
+        if (result.IsSuccess)
+        {
+            return result;
+        }
+
+        var files = result.Errors.Select(e => e.Message).ToImmutableList();
+        var fileLabel = files.Count == 1 ? "file remains" : "files remain";
+        var summary = $"{files.Count} {fileLabel} in the working directory:";
+
+        printer.Error(summary);
+        files.ForEach(file => printer.Warning($"• {file}"));
+
+        return Result.Fail(summary);
+    }
 }

--- a/src/CCVTAC.Console/IoUtilties/Directories.cs
+++ b/src/CCVTAC.Console/IoUtilties/Directories.cs
@@ -25,34 +25,19 @@ internal static class Directories
                         .ToImmutableList();
     }
 
-    internal static Result CheckIfEmpty(string directory)
+    internal static Result WarnIfAnyFiles(string directory, Printer printer)
     {
-        var files = GetDirectoryFiles(directory);
+        var fileNames = GetDirectoryFiles(directory);
 
-        if (files.IsEmpty)
+        if (fileNames.IsEmpty)
         {
             return Result.Ok();
         }
 
-        var errors = files.Select(f => new Error(f));
-        return Result.Fail(errors);
-    }
-
-    internal static Result WarnIfAnyFiles(string directory, Printer printer)
-    {
-        var result = CheckIfEmpty(directory);
-
-        if (result.IsSuccess)
-        {
-            return result;
-        }
-
-        var files = result.Errors.Select(e => e.Message).ToImmutableList();
-        var fileLabel = files.Count == 1 ? "file remains" : "files remain";
-        var summary = $"{files.Count} {fileLabel} in the working directory:";
-
+        var filesRemainLabel = fileNames.Count == 1 ? "file remains" : "files remain";
+        var summary = $"{fileNames.Count} {filesRemainLabel} in the working directory:";
         printer.Error(summary);
-        files.ForEach(file => printer.Warning($"• {file}"));
+        fileNames.ForEach(file => printer.Warning($"• {file}"));
 
         return Result.Fail(summary);
     }

--- a/src/CCVTAC.Console/PostProcessing/Deleter.cs
+++ b/src/CCVTAC.Console/PostProcessing/Deleter.cs
@@ -76,16 +76,4 @@ internal static class Deleter
             }
         }
     }
-
-    internal static void VerifyEmptyDirectory(string workingDirectory, Printer printer)
-    {
-        var tempFiles = IoUtilties.Directories.GetDirectoryFiles(workingDirectory);
-
-        if (tempFiles.IsEmpty)
-            return;
-
-        printer.Warning($"{tempFiles.Count} file(s) unexpectedly remain in the working folder:");
-        tempFiles.ForEach(file => printer.Warning($"• {file}"));
-
-    }
 }

--- a/src/CCVTAC.Console/PostProcessing/PostProcessing.cs
+++ b/src/CCVTAC.Console/PostProcessing/PostProcessing.cs
@@ -66,7 +66,7 @@ public sealed class PostProcessing
 
             var taggingSetFileNames = taggingSets.SelectMany(set => set.AllFiles).ToImmutableList();
             Deleter.Run(taggingSetFileNames, collectionJson, workingDirectory, verbose, Printer);
-            Deleter.VerifyEmptyDirectory(workingDirectory, Printer);
+            IoUtilties.Directories.WarnIfAnyFiles(workingDirectory, Printer);
         }
         else
         {

--- a/src/CCVTAC.Console/Program.cs
+++ b/src/CCVTAC.Console/Program.cs
@@ -84,21 +84,20 @@ internal static class Program
     private static void Start(UserSettings settings, History history, Printer printer)
     {
         // Verify the external program for downloading is installed on the system.
-        if (Downloading.Downloader.ExternalTool.ProgramExists() is { IsFailed: true })
+        if (Downloader.ExternalTool.ProgramExists() is { IsFailed: true })
         {
             printer.Error(
-                $"To use this program, please first install {Downloading.Downloader.ExternalTool.Name} " +
-                $"({Downloading.Downloader.ExternalTool.Url}) on this system.");
+                $"To use this program, please first install {Downloader.ExternalTool.Name} " +
+                $"({Downloader.ExternalTool.Url}) on this system.");
             printer.Print("Pass '--help' to this program for more information.");
             return;
         }
 
         // The working directory should start empty.
-        var tempFiles = IoUtilties.Directories.GetDirectoryFiles(settings.WorkingDirectory);
-        if (tempFiles.Any())
+        var workingDirResult = IoUtilties.Directories.WarnIfAnyFiles(settings.WorkingDirectory, printer);
+        if (workingDirResult.IsFailed)
         {
-            printer.Error($"Aborting due to {tempFiles.Count} file(s) unexpectedly found in the working directory ({settings.WorkingDirectory}):");
-            tempFiles.ForEach(file => printer.Warning($"• {file}"));
+            printer.Print($"Aborting...");
             return;
         }
 

--- a/src/CCVTAC.Console/Program.cs
+++ b/src/CCVTAC.Console/Program.cs
@@ -94,8 +94,8 @@ internal static class Program
         }
 
         // The working directory should start empty.
-        var workingDirResult = IoUtilties.Directories.WarnIfAnyFiles(settings.WorkingDirectory, printer);
-        if (workingDirResult.IsFailed)
+        var emptyDirResult = IoUtilties.Directories.WarnIfAnyFiles(settings.WorkingDirectory, printer);
+        if (emptyDirResult.IsFailed)
         {
             printer.Print($"Aborting...");
             return;


### PR DESCRIPTION
- DRY up code related to ensure the working directory is empty before and after downloading.
- Move empty-directory checking to the `IoUtilties.Directories` class
