### PR TITLE
Fix `history` command being ignored

### DIFF
--- a/src/CCVTAC.Console/UrlHelper.cs
+++ b/src/CCVTAC.Console/UrlHelper.cs
@@ -4,7 +4,7 @@ namespace CCVTAC.Console;
 
 public static class UrlHelper
 {
-    private static readonly Regex _httpsRegex = new("https:");
+    private static readonly Regex _httpsRegex = new("(?:https:|history)");
 
     private record IndexPair(int Start, int End);
 


### PR DESCRIPTION
I noticed that entering `history` at the prompt no longer shows the history. This is due to a tiny regex oversight in #47.