### PR TITLE
Move rename patterns to the settings file

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,64 +47,64 @@ Sample settings file with explanatory comments:
 
 ```
 {
-  // A temporary directory for working files.
-  // Cleared after processing a batch (i.e., URL).
+  # A temporary directory for working files.
+  # Cleared after processing a batch (i.e., URL).
   "workingDirectory": "/Users/me/temp",
 
-  // Where final audio files should be saved.
+  # Where final audio files should be saved.
   "moveToDirectory": "/Users/me/Downloads",
 
-  // A history of all URLs entered.
+  # A history of all URLs entered.
   "historyFile": "/Users/me/Downloads/history.log",
 
-  // Count of entries to show for `history` command
+  # Count of entries to show for `history` command
   "historyDisplayCount": 20,
 
-  // Should videos with chapters be split into separate files?
+  # Should videos with chapters be split into separate files?
   "splitChapters": true,
 
-  // Delay between video downloads for playlists and channels.
+  # Delay between video downloads for playlists and channels.
   "sleepSecondsBetweenDownloads": 10,
 
-  // Delay between batches (i.e., each URL entered)
+  # Delay between batches (i.e., each URL entered)
   "sleepSecondsBetweenBatches": 20,
 
-  // Use `false` for quiet mode.
+  # Use `false` for quiet mode.
   "verboseOutput": true,
 
-  // Is embedding video thumbnails into audio files enabled?
+  # Is embedding video thumbnails into audio files enabled?
   "embedImages": true,
 
-  // Channel names for which the video thumbnail should
-  // never be embedded in the audio file.
+  # Channel names for which the video thumbnail should
+  # never be embedded in the audio file.
   "doNotEmbedUploaders": [
     "Channel Name",
     "Another Channel Name"
   ],
 
-  // By default, the upload year of the video is
-  // saved to files' Year tag. However, this will
-  // not occur for videos on channels listed here.
+  # By default, the upload year of the video is
+  # saved to files' Year tag. However, this will
+  # not occur for videos on channels listed here.
   "ignoreUploadYearUploaders": [
     "Channel Name",
     "Another Channel Name"
   ],
 
-  // Collection of rules for auto-renaming audio files.
+  # Collection of rules for auto-renaming audio files.
   "renamePatterns": [
     {
-      // Regular expression that matches some or all of the filename.
+      # Regular expression that matches some or all of the filename.
       "regex": "\\s\\[[\\w_-]{11}\\](?=\\.\\w{3,5})",
 
-      // What the matched text should be replaced with.
+      # What the matched text should be replaced with.
       "replacePattern": "",
 
-      // Friendly summary to display in the output (if verbose output is on).
+      # Friendly summary to display in the output (if verbose output is on).
       "description": "Remove trailing video IDs"
     },
     {
-      // Use regex groups to match specific substrings that will then
-      // replace numbered placeholders in the replacement patterns!
+      # Use regex groups to match specific substrings that will then
+      # replace numbered placeholders in the replacement patterns!
       "regex": "【(.+)】(.+)",
       "replacePattern": "%<1>s - %<2>s",
       "description": "Change `【artist】title` to `ARTIST - TRACK`"

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Sample settings file with explanatory comments:
 
   # Channel names for which the video thumbnail should
   # never be embedded in the audio file.
-  "doNotEmbedUploaders": [
+  "doNotEmbedImageUploaders": [
     "Channel Name",
     "Another Channel Name"
   ],
@@ -129,7 +129,7 @@ Here's a mostly-empty setting files you can copy and paste to get started:
   "sleepSecondsBetweenBatches": 20,
   "verboseOutput": true,
   "embedImages": true,
-  "doNotEmbedUploaders": [
+  "doNotEmbedImageUploaders": [
     "Channel Name 1",
     "Channel Name 2"
   ],

--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@ Sample settings file with explanatory comments:
   # Delay between video downloads for playlists and channels.
   "sleepSecondsBetweenDownloads": 10,
 
-  # Delay between batches (i.e., each URL entered)
+  # Delay between batches (i.e., each URL entered).
   "sleepSecondsBetweenBatches": 20,
 
-  # Use `false` for quiet mode.
+  # Whether output should be verbose (true) or quiet (false).
   "verboseOutput": true,
 
-  # Is embedding video thumbnails into audio files enabled?
+  # Should video thumbnails be embedded into file tags?
   "embedImages": true,
 
   # Channel names for which the video thumbnail should
@@ -105,6 +105,7 @@ Sample settings file with explanatory comments:
     {
       # Use regex groups to match specific substrings that will then
       # replace numbered placeholders in the replacement patterns!
+      # (The placeholder numbers must match the regex groups'.)
       "regex": "【(.+)】(.+)",
       "replacePattern": "%<1>s - %<2>s",
       "description": "Change `【artist】title` to `ARTIST - TRACK`"
@@ -128,7 +129,10 @@ Here's a mostly-empty setting files you can copy and paste to get started:
   "sleepSecondsBetweenBatches": 20,
   "verboseOutput": true,
   "embedImages": true,
-  "doNotEmbedUploaders": [],
+  "doNotEmbedUploaders": [
+    "Channel Name 1",
+    "Channel Name 2"
+  ],
   "ignoreUploadYearUploaders": [
     "Channel Name 1",
     "Channel Name 2"

--- a/README.md
+++ b/README.md
@@ -54,25 +54,26 @@ Sample settings file with explanatory comments:
   # Where final audio files should be saved.
   "moveToDirectory": "/Users/me/Downloads",
 
-  # A history of all URLs entered.
+  # A local history of all URLs entered.
   "historyFile": "/Users/me/Downloads/history.log",
 
   # Count of entries to show for `history` command
   "historyDisplayCount": 20,
 
-  # Should videos with chapters be split into separate files?
+  # Split videos with chapters into separate files?
   "splitChapters": true,
 
-  # Delay between video downloads for playlists and channels.
+  # Delay in seconds between individual video downloads
+  # for playlists and channels.
   "sleepSecondsBetweenDownloads": 10,
 
-  # Delay between batches (i.e., each URL entered).
+  # Delay in seconds between batches (i.e., each URL entered).
   "sleepSecondsBetweenBatches": 20,
 
   # Whether output should be verbose (true) or quiet (false).
   "verboseOutput": true,
 
-  # Should video thumbnails be embedded into file tags?
+  # Embed video thumbnails into file tags?
   "embedImages": true,
 
   # Channel names for which the video thumbnail should
@@ -90,10 +91,10 @@ Sample settings file with explanatory comments:
     "Another Channel Name"
   ],
 
-  # Collection of rules for auto-renaming audio files.
+  # Rules for auto-renaming audio files.
   "renamePatterns": [
     {
-      # Regular expression that matches some or all of the filename.
+      # Regular expression that matches some or all of a filename.
       "regex": "\\s\\[[\\w_-]{11}\\](?=\\.\\w{3,5})",
 
       # What the matched text should be replaced with.
@@ -103,8 +104,9 @@ Sample settings file with explanatory comments:
       "description": "Remove trailing video IDs"
     },
     {
-      # Use regex groups to match specific substrings that will then
-      # replace numbered placeholders in the replacement patterns!
+      # Optionally use regex groups to match specific substrings.
+      # The matched groups will replace numbered placeholders (of
+      # the format `%<#>s`) in the replacement patterns!
       # (The placeholder numbers must match the regex groups'.)
       "regex": "【(.+)】(.+)",
       "replacePattern": "%<1>s - %<2>s",

--- a/README.md
+++ b/README.md
@@ -45,24 +45,36 @@ If your `settings.json` file does not exist, one will be created in the applicat
 
 Sample settings file:
 
-```
+```json
 {
-  "workingDirectory": "/Users/me/temp",             // A temporary home for working files
-  "moveToDirectory": "/Users/me/Downloads",         // Where final audio files should be saved
-  "historyFile": "/Users/me/Downloads/history.log", // Log for your entered URLs
-  "historyDisplayCount": 20,                        // Count of entries to show for `history` command
-  "splitChapters": true,                            // Split videos with chapters into separate files?
-  "sleepSecondsBetweenDownloads": 10,               // Delay between video downloads in playlists and channels
-  "sleepSecondsBetweenBatches": 20,                 // Delay between batches (i.e., each URL entered)
-  "verboseOutput": true,                            // Use `false` for quiet mode
-  "embedImages": true,                              // Is embedding video thumbnails into audio files enabled?
-  "doNotEmbedUploaders": [                          // Channel names for which the video thumbnail should
-    "Channel Name",                                 //   never be embedded in the audio file.
-    "Another Channel Name
+  "workingDirectory": "/Users/me/temp",                // A temporary home for working files
+  "moveToDirectory": "/Users/me/Downloads",            // Where final audio files should be saved
+  "historyFile": "/Users/me/Downloads/history.log",    // Log for your entered URLs
+  "historyDisplayCount": 20,                           // Count of entries to show for `history` command
+  "splitChapters": true,                               // Split videos with chapters into separate files?
+  "sleepSecondsBetweenDownloads": 10,                  // Delay between video downloads in playlists and channels
+  "sleepSecondsBetweenBatches": 20,                    // Delay between batches (i.e., each URL entered)
+  "verboseOutput": true,                               // Use `false` for quiet mode
+  "embedImages": true,                                 // Is embedding video thumbnails into audio files enabled?
+  "doNotEmbedUploaders": [                             // Channel names for which the video thumbnail should
+    "Channel Name",                                    //   never be embedded in the audio file.
+    "Another Channel Name"
   ],
-  "ignoreUploadYearUploaders": [                    // By default, the upload year of the video is
-    "Channel Name",                                 //   saved to files' Year tag. However, this will
-    "Another Channel Name"                          //   not occur for videos on channels listed here.
+  "ignoreUploadYearUploaders": [                       // By default, the upload year of the video is
+    "Channel Name",                                    //   saved to files' Year tag. However, this will
+    "Another Channel Name"                             //   not occur for videos on channels listed here.
+  ],
+  "renamePatterns": [                                  // Collection of rules for auto-renaming audio files.
+    {
+      "regex": "\\s\\[[\\w_-]{11}\\](?=\\.\\w{3,5})",  // Regular expression that matches some or all of the filename.
+      "replacePattern": "",                            // What the matched text should be replaced with.
+      "description": "Remove trailing video IDs"       // Summary to display in the output (if "verbose" is on).
+    },
+    {
+      "regex": "【(.+)】(.+)",                         // Use regex groups to match specific text that will then
+      "replacePattern": "%<1>s - %<2>s",              // replace numbered placeholders in the replacement patterns!
+      "description": "Change `【artist】title` to `ARTIST - TRACK`"
+    },
   ]
 }
 ```
@@ -71,19 +83,29 @@ I added the `sleepSecondsBetweenDownloads` and `sleepSecondsBetweenBatches` sett
 
 Here's a mostly-empty version you can copy and paste:
 
-```
+```json
 {
   "workingDirectory": "",
-  "moveToDirectory": ""
-  "historyFile": ""
+  "moveToDirectory": "",
+  "historyFile": "",
   "historyDisplayCount": 20,
   "splitChapters": true,
-  "sleepSecondsBetweenDownloads": 10
-  "sleepSecondsBetweenBatches": 20
+  "sleepSecondsBetweenDownloads": 10,
+  "sleepSecondsBetweenBatches": 20,
   "verboseOutput": true,
   "embedImages": true,
   "doNotEmbedUploaders": [],
-  "ignoreUploadYearUploaders": []
+  "ignoreUploadYearUploaders": [
+    "Channel Name 1",
+    "Channel Name 2"
+  ],
+  "renamePatterns": [
+    {
+      "regex": "\\s\\[[\\w_-]{11}\\](?=\\.\\w{3,5})",
+      "replacePattern": "",
+      "description": "Remove trailing video IDs (recommend running this first)"
+    },
+  ]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -43,36 +43,70 @@ By default, the application will look for a file named `settings.json` in its di
 
 If your `settings.json` file does not exist, one will be created in the application directory with default settings. At minimum, you will need to enter (1) an existing directory for temporary working files, (2) an existing directory to which the final audio files should be moved, and (3) a path to your history file. The other settings have sensible defaults.
 
-Sample settings file:
+Sample settings file with explanatory comments:
 
-```json
+```
 {
-  "workingDirectory": "/Users/me/temp",                // A temporary home for working files
-  "moveToDirectory": "/Users/me/Downloads",            // Where final audio files should be saved
-  "historyFile": "/Users/me/Downloads/history.log",    // Log for your entered URLs
-  "historyDisplayCount": 20,                           // Count of entries to show for `history` command
-  "splitChapters": true,                               // Split videos with chapters into separate files?
-  "sleepSecondsBetweenDownloads": 10,                  // Delay between video downloads in playlists and channels
-  "sleepSecondsBetweenBatches": 20,                    // Delay between batches (i.e., each URL entered)
-  "verboseOutput": true,                               // Use `false` for quiet mode
-  "embedImages": true,                                 // Is embedding video thumbnails into audio files enabled?
-  "doNotEmbedUploaders": [                             // Channel names for which the video thumbnail should
-    "Channel Name",                                    //   never be embedded in the audio file.
+  // A temporary directory for working files.
+  // Cleared after processing a batch (i.e., URL).
+  "workingDirectory": "/Users/me/temp",
+
+  // Where final audio files should be saved.
+  "moveToDirectory": "/Users/me/Downloads",
+
+  // A history of all URLs entered.
+  "historyFile": "/Users/me/Downloads/history.log",
+
+  // Count of entries to show for `history` command
+  "historyDisplayCount": 20,
+
+  // Should videos with chapters be split into separate files?
+  "splitChapters": true,
+
+  // Delay between video downloads for playlists and channels.
+  "sleepSecondsBetweenDownloads": 10,
+
+  // Delay between batches (i.e., each URL entered)
+  "sleepSecondsBetweenBatches": 20,
+
+  // Use `false` for quiet mode.
+  "verboseOutput": true,
+
+  // Is embedding video thumbnails into audio files enabled?
+  "embedImages": true,
+
+  // Channel names for which the video thumbnail should
+  // never be embedded in the audio file.
+  "doNotEmbedUploaders": [
+    "Channel Name",
     "Another Channel Name"
   ],
-  "ignoreUploadYearUploaders": [                       // By default, the upload year of the video is
-    "Channel Name",                                    //   saved to files' Year tag. However, this will
-    "Another Channel Name"                             //   not occur for videos on channels listed here.
+
+  // By default, the upload year of the video is
+  // saved to files' Year tag. However, this will
+  // not occur for videos on channels listed here.
+  "ignoreUploadYearUploaders": [
+    "Channel Name",
+    "Another Channel Name"
   ],
-  "renamePatterns": [                                  // Collection of rules for auto-renaming audio files.
+
+  // Collection of rules for auto-renaming audio files.
+  "renamePatterns": [
     {
-      "regex": "\\s\\[[\\w_-]{11}\\](?=\\.\\w{3,5})",  // Regular expression that matches some or all of the filename.
-      "replacePattern": "",                            // What the matched text should be replaced with.
-      "description": "Remove trailing video IDs"       // Summary to display in the output (if "verbose" is on).
+      // Regular expression that matches some or all of the filename.
+      "regex": "\\s\\[[\\w_-]{11}\\](?=\\.\\w{3,5})",
+
+      // What the matched text should be replaced with.
+      "replacePattern": "",
+
+      // Friendly summary to display in the output (if verbose output is on).
+      "description": "Remove trailing video IDs"
     },
     {
-      "regex": "【(.+)】(.+)",                         // Use regex groups to match specific text that will then
-      "replacePattern": "%<1>s - %<2>s",              // replace numbered placeholders in the replacement patterns!
+      // Use regex groups to match specific substrings that will then
+      // replace numbered placeholders in the replacement patterns!
+      "regex": "【(.+)】(.+)",
+      "replacePattern": "%<1>s - %<2>s",
       "description": "Change `【artist】title` to `ARTIST - TRACK`"
     },
   ]
@@ -81,7 +115,7 @@ Sample settings file:
 
 I added the `sleepSecondsBetweenDownloads` and `sleepSecondsBetweenBatches` settings to help reduce concentrated loads on YouTube servers. Please use reasonable values to avoid slamming them with enormous, long-running downloads.
 
-Here's a mostly-empty version you can copy and paste:
+Here's a mostly-empty setting files you can copy and paste to get started:
 
 ```json
 {

--- a/src/CCVTAC.Console/PostProcessing/PostProcessing.cs
+++ b/src/CCVTAC.Console/PostProcessing/PostProcessing.cs
@@ -59,7 +59,7 @@ public sealed class PostProcessing
             Printer.Print(tagResult.Value);
 
             // AudioNormalizer.Run(workingDirectory, Printer); // TODO: normalize方法を要検討。
-            Renamer.Run(Settings, workingDirectory, verbose, Printer);
+            Renamer.Run(Settings, workingDirectory, Printer);
             Mover.Run(taggingSets, collectionJson, Settings, true, Printer);
 
             var taggingSetFileNames = taggingSets.SelectMany(set => set.AllFiles).ToImmutableList();

--- a/src/CCVTAC.Console/PostProcessing/PostProcessing.cs
+++ b/src/CCVTAC.Console/PostProcessing/PostProcessing.cs
@@ -59,7 +59,7 @@ public sealed class PostProcessing
             Printer.Print(tagResult.Value);
 
             // AudioNormalizer.Run(workingDirectory, Printer); // TODO: normalize方法を要検討。
-            Renamer.Run(workingDirectory, verbose, Printer);
+            Renamer.Run(Settings, workingDirectory, verbose, Printer);
             Mover.Run(taggingSets, collectionJson, Settings, true, Printer);
 
             var taggingSetFileNames = taggingSets.SelectMany(set => set.AllFiles).ToImmutableList();

--- a/src/CCVTAC.Console/PostProcessing/Renamer.cs
+++ b/src/CCVTAC.Console/PostProcessing/Renamer.cs
@@ -10,10 +10,10 @@ internal static class Renamer
     public static void Run(
         UserSettings settings,
         string workingDirectory,
-        bool verbose,
         Printer printer)
     {
         Watch watch = new();
+        bool verbose = settings.VerboseOutput;
 
         DirectoryInfo dir = new(workingDirectory);
         var audioFilePaths = dir.EnumerateFiles("*.m4a");

--- a/src/CCVTAC.Console/PostProcessing/Tagging/Tagger.cs
+++ b/src/CCVTAC.Console/PostProcessing/Tagging/Tagger.cs
@@ -178,7 +178,7 @@ internal static class Tagger
             taggedFile.Tag.Comment = videoData.GenerateComment(collectionData);
 
             if (settings.EmbedImages &&
-                !settings.DoNotEmbedUploaders.Contains(videoData.Uploader) &&
+                !settings.DoNotEmbedImageUploaders.Contains(videoData.Uploader) &&
                 imageFilePath is not null)
             {
                 printer.Print("Embedding the image.");

--- a/src/CCVTAC.FSharp/Settings.fs
+++ b/src/CCVTAC.FSharp/Settings.fs
@@ -22,7 +22,7 @@ module Settings =
         [<JsonPropertyName("sleepSecondsBetweenBatches")>]   SleepSecondsBetweenBatches: uint16
         [<JsonPropertyName("verboseOutput")>]                VerboseOutput: bool
         [<JsonPropertyName("embedImages")>]                  EmbedImages: bool
-        [<JsonPropertyName("doNotEmbedUploaders")>]          DoNotEmbedUploaders: string array
+        [<JsonPropertyName("doNotEmbedImageUploaders")>]     DoNotEmbedImageUploaders: string array
         [<JsonPropertyName("ignoreUploadYearUploaders")>]    IgnoreUploadYearUploaders: string array
         [<JsonPropertyName("renamePatterns")>]               RenamePatterns: RenamePattern array
     }
@@ -41,6 +41,7 @@ module Settings =
             ("Sleep between batches", settings.SleepSecondsBetweenBatches |> int |> pluralize  "second")
             ("Sleep between downloads", settings.SleepSecondsBetweenDownloads |> int |> pluralize "second")
             ("Ignore-upload-year channels", settings.IgnoreUploadYearUploaders.Length |> pluralize "channel")
+            ("Do-not-embed-image channels", settings.DoNotEmbedImageUploaders.Length |> pluralize "channel")
             ("Rename patterns", settings.RenamePatterns.Length |> pluralize "pattern")
             ("Working directory", settings.WorkingDirectory)
             ("Move-to directory", settings.MoveToDirectory)
@@ -123,7 +124,7 @@ module Settings =
                   SleepSecondsBetweenBatches = 20us
                   VerboseOutput = true
                   EmbedImages = true
-                  DoNotEmbedUploaders = [||]
+                  DoNotEmbedImageUploaders = [||]
                   IgnoreUploadYearUploaders = [||]
                   RenamePatterns = [||] }
             writeFile defaultSettings confirmedPath

--- a/src/CCVTAC.FSharp/Settings.fs
+++ b/src/CCVTAC.FSharp/Settings.fs
@@ -2,8 +2,15 @@ namespace CCVTAC.FSharp
 
 module Settings =
     open System.Text.Json.Serialization
+    open System
 
     type FilePath = FilePath of string
+
+    type RenamePattern = {
+        [<JsonPropertyName("regex")>]          Regex : string
+        [<JsonPropertyName("replacePattern")>] ReplaceWithPattern : string
+        [<JsonPropertyName("description")>]    Description : string
+    }
 
     type UserSettings = {
         [<JsonPropertyName("workingDirectory")>]             WorkingDirectory: string
@@ -17,6 +24,7 @@ module Settings =
         [<JsonPropertyName("embedImages")>]                  EmbedImages: bool
         [<JsonPropertyName("doNotEmbedUploaders")>]          DoNotEmbedUploaders: string array
         [<JsonPropertyName("ignoreUploadYearUploaders")>]    IgnoreUploadYearUploaders: string array
+        [<JsonPropertyName("renamePatterns")>]               RenamePatterns: RenamePattern array
     }
 
     [<CompiledName("Summarize")>]
@@ -33,13 +41,13 @@ module Settings =
             ("Sleep between batches", settings.SleepSecondsBetweenBatches |> int |> pluralize  "second")
             ("Sleep between downloads", settings.SleepSecondsBetweenDownloads |> int |> pluralize "second")
             ("Ignore-upload-year channels", settings.IgnoreUploadYearUploaders.Length |> pluralize "channel")
+            ("Rename patterns", settings.RenamePatterns.Length |> pluralize "pattern")
             ("Working directory", settings.WorkingDirectory)
             ("Move-to directory", settings.MoveToDirectory)
             ("History log file", settings.HistoryFile)
         ]
 
     module IO =
-        open System
         open System.IO
         open System.Text.Json
         open System.Text.Unicode
@@ -79,7 +87,7 @@ module Settings =
                 |> verify
             with
                 | :? FileNotFoundException -> Error $"\"{path}\" was not found."
-                | :? JsonException -> Error $"Could not parse JSON in \"{path}\" to settings."
+                | :? JsonException as e -> Error $"Could not parse settings file \"{path}\": {e.Message}"
                 | e -> Error $"Settings unexpectedly could not be read from \"{path}\": {e.Message}"
 
         [<CompiledName("WriteFile")>]
@@ -116,5 +124,6 @@ module Settings =
                   VerboseOutput = true
                   EmbedImages = true
                   DoNotEmbedUploaders = [||]
-                  IgnoreUploadYearUploaders = [||] }
+                  IgnoreUploadYearUploaders = [||]
+                  RenamePatterns = [||] }
             writeFile defaultSettings confirmedPath


### PR DESCRIPTION
Rename patterns have been baked into the code since this tool's inception, but I've finally moved them to the JSON settings file! 🎉  This enables customization of the patterns by users.

On the downside, this requires double escaping some characters in the regexes, but that should only be an occasional inconvenience when editing them.