### PR TITLE
Allow comments in JSON settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ If your `settings.json` file does not exist, one will be created in the applicat
 
 You can copy and paste this file to `settings.json` to get started. You will, in particular, need to update the three directories at the top.
 
+<details>
+  <summary>Click here to expand the settings!</summary>
+
 ```
 {
   // Mandatory. A temporary directory for working files.
@@ -143,6 +146,7 @@ You can copy and paste this file to `settings.json` to get started. You will, in
   ]
 }
 ```
+</details>
 
 ### Using the application
 

--- a/README.md
+++ b/README.md
@@ -36,104 +36,106 @@ By default, the application will look for a file named `settings.json` in its di
 
 If your `settings.json` file does not exist, one will be created in the application directory with default settings. At minimum, you will need to enter (1) an existing directory for temporary working files, (2) an existing directory to which the final audio files should be moved, and (3) a path to your history file. The other settings have sensible defaults.
 
-#### Sample file with explanatory comments
+#### Starter file with comments
+
+You can copy and paste this file to `settings.json` to get started. You will, in particular, need to update the three directories at the top.
 
 ```
 {
-  # Mandatory. A temporary directory for working files.
-  # Cleared after processing a batch (i.e., URL).
+  // Mandatory. A temporary directory for working files.
+  // Cleared after processing a batch (i.e., URL).
   "workingDirectory": "/Users/me/temp",
 
-  # Mandatory. Where final audio files should be saved.
+  // Mandatory. Where final audio files should be saved.
   "moveToDirectory": "/Users/me/Downloads",
 
-  # Mandatory. A local history of all URLs entered.
+  // Mandatory. A local history of all URLs entered.
   "historyFile": "/Users/me/Downloads/history.log",
 
-  # Count of entries to show for `history` command
+  // Count of entries to show for `history` command
   "historyDisplayCount": 20,
 
-  # Split videos with chapters into separate files?
+  // Split videos with chapters into separate files?
   "splitChapters": true,
 
-  # Delay in seconds between individual video downloads for
-  # playlists and channels. Use to avoid slamming YouTube servers
-  # with several downloads in succession.
+  // Delay in seconds between individual video downloads for
+  // playlists and channels. Use to avoid slamming YouTube servers
+  // with several downloads in succession.
   "sleepSecondsBetweenDownloads": 10,
 
-  # Delay in seconds between batches (i.e., each URL entered).
-  # Use to avoid slamming YouTube servers with several downloads
-  # in succession.
+  // Delay in seconds between batches (i.e., each URL entered).
+  // Use to avoid slamming YouTube servers with several downloads
+  // in succession.
   "sleepSecondsBetweenBatches": 20,
 
   # Whether to use quiet mode (true) or not (false).
   # Less output is shown in quiet mode.
   "quietMode": false,
 
-  # Embed video thumbnails into file tags?
+  // Embed video thumbnails into file tags?
   "embedImages": true,
 
-  # Channel names for which the video thumbnail should
-  # never be embedded in the audio file.
+  // Channel names for which the video thumbnail should
+  // never be embedded in the audio file.
   "doNotEmbedImageUploaders": [
     "Channel Name",
     "Another Channel Name"
   ],
 
-  # By default, the upload year of the video is
-  # saved to files' Year tag. However, this will
-  # not occur for videos on channels listed here.
+  // By default, the upload year of the video is
+  // saved to files' Year tag. However, this will
+  // not occur for videos on channels listed here.
   "ignoreUploadYearUploaders": [
     "Channel Name",
     "Another Channel Name"
   ],
 
-  # Rules for detecting tag data from video metadata.
+  // Rules for detecting tag data from video metadata.
   "tagDetectionPatterns": {
 
-    # Currently supports 5 tags -- this one (Title) and its siblings.
+    // Currently supports 5 tags -- this one (Title) and its siblings.
     "title": [
       {
-        # A regex pattern for searching in the video metadata field specified below.
+        // A regex pattern for searching in the video metadata field specified below.
         "regex": "(.+?) · (.+)(?:\n|\r|\r\n){2}(.+)(?:\n|\r|\r\n){2}.*℗ ([12]\\d{3})\\D",
 
-        # Use the text that comprises this match group number.
-        # `1` and greater indicates the specified group. You must use groups in the regex pattern!
-        # `0` indicates the entirety of the match text.
+        // Use the text that comprises this match group number.
+        // `1` and greater indicates the specified group. You must use groups in the regex pattern!
+        // `0` indicates the entirety of the match text.
         "matchGroup": 1,
 
-        # Which video metadata field should be searched, `title` or `description`?
+        // Which video metadata field should be searched, `title` or `description`?
         "searchField": "description",
 
-        # An arbitrary name for the rule. It will appear in the output when this pattern is matched.
+        // An arbitrary name for the rule. It will appear in the output when this pattern is matched.
         "summary": "Topic style"
       }
     ],
 
-    # The same data format is applicable to these tags as well.
+    // The same data format is applicable to these tags as well.
     "artist": [],
     "album": [],
     "composer": [],
     "year": []
   },
 
-  # Rules for auto-renaming audio files.
+  // Rules for auto-renaming audio files.
   "renamePatterns": [
     {
-      # Regular expression that matches some or all of a filename.
+      // Regular expression that matches some or all of a filename.
       "regex": "\\s\\[[\\w_-]{11}\\](?=\\.\\w{3,5})",
 
-      # What the matched text should be replaced with.
+      // What the matched text should be replaced with.
       "replacePattern": "",
 
       # Friendly summary to display in the output (if quiet mode is off).
       "description": "Remove trailing video IDs"
     },
     {
-      # Optionally use regex groups to match specific substrings.
-      # The matched groups will replace numbered placeholders (of
-      # the format `%<#>s`) in the replacement patterns!
-      # (The placeholder numbers must match the regex groups'.)
+      // Optionally use regex groups to match specific substrings.
+      // The matched groups will replace numbered placeholders (of
+      // the format `%<#>s`) in the replacement patterns!
+      // (The placeholder numbers must match the regex groups'.)
       "regex": "【(.+)】(.+)",
       "replacePattern": "%<1>s - %<2>s",
       "description": "Change `【artist】title` to `ARTIST - TRACK`"
@@ -155,7 +157,7 @@ Below is a mostly-empty settings you can copy and save to `settings.json` to get
   "splitChapters": true,
   "sleepSecondsBetweenDownloads": 10,
   "sleepSecondsBetweenBatches": 20,
-  "quietMode": false,
+  "verboseOutput": true,
   "embedImages": true,
   "doNotEmbedImageUploaders": [
     "Channel Name 1",

--- a/README.md
+++ b/README.md
@@ -34,25 +34,25 @@ A valid settings file is mandatory to use this application.
 
 By default, the application will look for a file named `settings.json` in its directory. However, you can manually specify an existing file path using the `-s` option, such as `dotnet run -- -s <PATH_TO_YOUR_FILE>`.
 
-If your `settings.json` file does not exist, one will be created in the application directory with default settings. At minimum, you will need to enter (1) an existing directory for temporary working files, (2) an existing directory to which the final audio files should be moved, and (3) a path to your history file. The other settings have sensible defaults.
+If your `settings.json` file does not exist, one will be created in the application directory with default settings. At minimum, you will need to enter (1) an existing directory for temporary working files, (2) an existing directory to which the final audio files should be moved, and (3) a path to your history file. The other settings have sensible defaults. Some settings require familiarity with regular expressions (regex).
 
 #### Starter file with comments
 
-You can copy and paste this file to `settings.json` to get started. You will, in particular, need to update the three directories at the top.
+You can copy and paste the sample settings file below to a JSON file named `settings.json` to get started. You will, in particular, need to update the three directories at the top. You can leave the commented lines as-is, as they will be ignored.
 
 <details>
-  <summary>Click here to expand the settings!</summary>
+  <summary>Click here to expand!</summary>
 
 ```
 {
-  // Mandatory. A temporary directory for working files.
-  // Cleared after processing a batch (i.e., URL).
+  // Mandatory. The working directory for temporary files.
+  // It is cleared after processing each URL.
   "workingDirectory": "/Users/me/temp",
 
-  // Mandatory. Where final audio files should be saved.
+  // Mandatory. The directory in which final audio files should be saved.
   "moveToDirectory": "/Users/me/Downloads",
 
-  // Mandatory. A local history of all URLs entered.
+  // Mandatory. A local file containing the history of all URLs entered.
   "historyFile": "/Users/me/Downloads/history.log",
 
   // Count of entries to show for `history` command
@@ -62,17 +62,17 @@ You can copy and paste this file to `settings.json` to get started. You will, in
   "splitChapters": true,
 
   // Delay in seconds between individual video downloads for
-  // playlists and channels. Use to avoid slamming YouTube servers
-  // with several downloads in succession.
+  // playlists and channels. Use to avoid burdening YouTube servers
+  // with several downloads in quick succession.
   "sleepSecondsBetweenDownloads": 10,
 
   // Delay in seconds between batches (i.e., each URL entered).
-  // Use to avoid slamming YouTube servers with several downloads
-  // in succession.
+  // Use to avoid burdening YouTube servers with several downloads
+  // in quick succession.
   "sleepSecondsBetweenBatches": 20,
 
   # Whether to use quiet mode (true) or not (false).
-  # Less output is shown in quiet mode.
+  # Fewer details are shown in quiet mode.
   "quietMode": false,
 
   // Embed video thumbnails into file tags?
@@ -85,37 +85,38 @@ You can copy and paste this file to `settings.json` to get started. You will, in
     "Another Channel Name"
   ],
 
-  // By default, the upload year of the video is
-  // saved to files' Year tag. However, this will
-  // not occur for videos on channels listed here.
+  // By default, the upload year of the video is saved to files' Year tag.
+  // However, this will not occur for videos on channels listed here.
   "ignoreUploadYearUploaders": [
     "Channel Name",
     "Another Channel Name"
   ],
 
   // Rules for detecting tag data from video metadata.
+  // These require familiarity with regular expressions (regex).
   "tagDetectionPatterns": {
 
-    // Currently supports 5 tags -- this one (Title) and its siblings.
+    // Currently supports 5 tags: this one (Title) and its siblings listed below.
     "title": [
       {
         // A regex pattern for searching in the video metadata field specified below.
         "regex": "(.+?) · (.+)(?:\n|\r|\r\n){2}(.+)(?:\n|\r|\r\n){2}.*℗ ([12]\\d{3})\\D",
 
-        // Use the text that comprises this match group number.
-        // `1` and greater indicates the specified group. You must use groups in the regex pattern!
-        // `0` indicates the entirety of the match text.
+        // Specify the number of match group whose text should be used.
+        // `1` and greater indicates a group number. In this case, you must specify groups in the regex pattern!
+        // `0` indicates the entirety of the matched text. In this case, specifying groups is unnecessary.
         "matchGroup": 1,
 
         // Which video metadata field should be searched, `title` or `description`?
         "searchField": "description",
 
-        // An arbitrary name for the rule. It will appear in the output when this pattern is matched.
+        // An arbitrary summary to the rule. If quiet mode is off, this name will appear
+        // in the output when this pattern is matched.
         "summary": "Topic style"
       }
     ],
 
-    // The same data format is applicable to these tags as well.
+    // The same format is applicable to these tags as well.
     "artist": [],
     "album": [],
     "composer": [],
@@ -126,19 +127,23 @@ You can copy and paste this file to `settings.json` to get started. You will, in
   "renamePatterns": [
     {
       // Regular expression that matches some or all of a filename.
+      // This one matches the 11-digit media ID and surrounding
+      // square brackets in downloaded filenames.
       "regex": "\\s\\[[\\w_-]{11}\\](?=\\.\\w{3,5})",
 
       // What the matched text should be replaced with.
+      // `""` indicates that the matched text should simply be removed.
       "replacePattern": "",
 
-      # Friendly summary to display in the output (if quiet mode is off).
+      // An arbitrary summary to the rule. If quiet mode is off, this name will appear
+      // in the output when this pattern is matched.
       "description": "Remove trailing video IDs"
     },
     {
       // Optionally use regex groups to match specific substrings.
       // The matched groups will replace numbered placeholders (of
       // the format `%<#>s`) in the replacement patterns!
-      // (The placeholder numbers must match the regex groups'.)
+      // The placeholder numbers must match the regex group numbers.
       "regex": "【(.+)】(.+)",
       "replacePattern": "%<1>s - %<2>s",
       "description": "Change `【artist】title` to `ARTIST - TRACK`"
@@ -167,4 +172,4 @@ Periodically ensure you are running the latest version of yt-dlp, especially if 
 
 ## Reporting issues
 
-If you run into any issues, feel free to create an issue on GitHub with as much information as possible (e.g., entered URLs, system information, yt-dlp version).
+If you run into any issues, please create an issue on GitHub with as much information as possible (e.g., entered URLs, OS, .NET version, yt-dlp version, etc.).

--- a/README.md
+++ b/README.md
@@ -144,53 +144,6 @@ You can copy and paste this file to `settings.json` to get started. You will, in
 }
 ```
 
-#### Starting template
-
-Below is a mostly-empty settings you can copy and save to `settings.json` to get started. Be sure to fill out the first three entries!
-
-```json
-{
-  "workingDirectory": "",
-  "moveToDirectory": "",
-  "historyFile": "",
-  "historyDisplayCount": 20,
-  "splitChapters": true,
-  "sleepSecondsBetweenDownloads": 10,
-  "sleepSecondsBetweenBatches": 20,
-  "verboseOutput": true,
-  "embedImages": true,
-  "doNotEmbedImageUploaders": [
-    "Channel Name 1",
-    "Channel Name 2"
-  ],
-  "ignoreUploadYearUploaders": [
-    "Channel Name 1",
-    "Channel Name 2"
-  ],
-  "tagDetectionPatterns": {
-    "title": [
-      {
-        "regex": "(.+?) · (.+)(?:\n|\r|\r\n){2}(.+)(?:\n|\r|\r\n){2}.*℗ ([12]\\d{3})\\D",
-        "matchGroup": 1,
-        "searchField": "description",
-        "summary": "Topic style"
-      }
-    ],
-    "artist": [],
-    "album": [],
-    "composer": [],
-    "year": []
-  },
-  "renamePatterns": [
-    {
-      "regex": "\\s\\[[\\w_-]{11}\\](?=\\.\\w{3,5})",
-      "replacePattern": "",
-      "description": "Remove trailing video IDs (recommend running this first)"
-    }
-  ]
-}
-```
-
 ### Using the application
 
 Once your settings file is ready, run the application with `dotnet run`. Optionally, pass `-h` or `--help` for instructions (e.g., `dotnet run -- --help`).

--- a/src/CCVTAC.FSharp/Settings.fs
+++ b/src/CCVTAC.FSharp/Settings.fs
@@ -108,6 +108,13 @@ module Settings =
         open System.Text.Unicode
         open System.Text.Encodings.Web
 
+        let deserialize<'a> (json:string) =
+            let options = new JsonSerializerOptions()
+            options.AllowTrailingCommas <- true
+            options.ReadCommentHandling <- JsonCommentHandling.Skip
+
+            JsonSerializer.Deserialize<'a>(json, options)
+
         [<CompiledName("FileExists")>]
         let fileExists filePath =
             let (FilePath file) = filePath
@@ -138,7 +145,7 @@ module Settings =
             try
                 path
                 |> File.ReadAllText
-                |> JsonSerializer.Deserialize<UserSettings>
+                |> deserialize<UserSettings>
                 |> verify
             with
                 | :? FileNotFoundException -> Error $"\"{path}\" was not found."


### PR DESCRIPTION
I found that .NET supports comments in JSON if provided with the right options. I've enabled that to make the creation of empty settings a bit easier.