### PR TITLE
Allow more channel URL types

### DIFF
--- a/src/CCVTAC.FSharp/Downloading.fs
+++ b/src/CCVTAC.FSharp/Downloading.fs
@@ -33,7 +33,7 @@ module public Downloading =
         | Regex @"((?:www\.)?youtube\.com\/(?:channel\/|c\/|user\/|@)(?:[A-Za-z0-9\-@%\/]+))" [ id ] ->
             Ok (Channel id)
         | _ ->
-            Error "Unable to determine the media type of the URL."
+            Error "Unable to determine the URL media type. (Might it contain invalid non-alphanumeric characters?)"
 
     [<CompiledName("ExtractDownloadUrls")>]
     let extractDownloadUrls mediaType =

--- a/src/CCVTAC.FSharp/Downloading.fs
+++ b/src/CCVTAC.FSharp/Downloading.fs
@@ -30,7 +30,7 @@ module public Downloading =
             Ok (StandardPlaylist id)
         | Regex @"(?<=list=)(O[\w\-]+)" [id] ->
             Ok (ReleasePlaylist id)
-        | Regex @"((?:www\.)?youtube\.com\/(?:channel\/|c\/|user\/|@)(?:[\w\-]+))" [ id ] ->
+        | Regex @"((?:www\.)?youtube\.com\/(?:channel\/|c\/|user\/|@)(?:[A-Za-z0-9\-@%\/]+))" [ id ] ->
             Ok (Channel id)
         | _ ->
             Error "Unable to determine the media type of the URL."


### PR DESCRIPTION
Channel URLs with encoded Japanese characters would fail to be detected, so I've fixed that.