### PR TITLE
Elide " - Topic" from directory names

### DIFF
--- a/src/CCVTAC.Console/PostProcessing/Mover.cs
+++ b/src/CCVTAC.Console/PostProcessing/Mover.cs
@@ -182,21 +182,26 @@ internal static class Mover
 
     private static string GetSafeSubDirectoryName(CollectionMetadata? maybeCollectionData, TaggingSet taggingSet)
     {
+        const string topicSuffix = " - Topic"; // Official channels append this to artist names.
         string workingName;
 
         if (maybeCollectionData is CollectionMetadata collectionData &&
             collectionData.Uploader.HasText() &&
             collectionData.Title.HasText())
         {
-            workingName = $"{collectionData.Uploader}";
+            workingName = collectionData.Uploader.EndsWith(topicSuffix)
+                ? collectionData.Uploader.Replace(topicSuffix, string.Empty)
+                : collectionData.Uploader;
         }
         else
         {
             var jsonResult = GetParsedVideoJson(taggingSet);
 
-            workingName = jsonResult.IsSuccess
-                ? jsonResult.Value.Uploader
-                : string.Empty;
+            workingName = jsonResult.IsFailed
+                ? string.Empty
+                : jsonResult.Value.Uploader.EndsWith(topicSuffix)
+                    ? jsonResult.Value.Uploader.Replace(topicSuffix, string.Empty)
+                    : jsonResult.Value.Uploader;
         }
 
         return workingName.ReplaceInvalidPathChars().Trim();

--- a/src/CCVTAC.Console/PostProcessing/Mover.cs
+++ b/src/CCVTAC.Console/PostProcessing/Mover.cs
@@ -199,8 +199,9 @@ internal static class Mover
                 : string.Empty;
         }
 
-        const string topicSuffix = " - Topic"; // Official channels append this to artist names.
         var safeName = workingName.ReplaceInvalidPathChars().Trim();
+
+        const string topicSuffix = " - Topic"; // Official channels append this to uploader names.
         return safeName.EndsWith(topicSuffix)
             ? safeName.Replace(topicSuffix, string.Empty)
             : safeName;

--- a/src/CCVTAC.Console/PostProcessing/Mover.cs
+++ b/src/CCVTAC.Console/PostProcessing/Mover.cs
@@ -180,31 +180,30 @@ internal static class Mover
         }
     }
 
-    private static string GetSafeSubDirectoryName(CollectionMetadata? maybeCollectionData, TaggingSet taggingSet)
+    private static string GetSafeSubDirectoryName(CollectionMetadata? collectionData, TaggingSet taggingSet)
     {
-        const string topicSuffix = " - Topic"; // Official channels append this to artist names.
         string workingName;
 
-        if (maybeCollectionData is CollectionMetadata collectionData &&
-            collectionData.Uploader.HasText() &&
-            collectionData.Title.HasText())
+        if (collectionData is CollectionMetadata metadata &&
+            metadata.Uploader.HasText() &&
+            metadata.Title.HasText())
         {
-            workingName = collectionData.Uploader.EndsWith(topicSuffix)
-                ? collectionData.Uploader.Replace(topicSuffix, string.Empty)
-                : collectionData.Uploader;
+            workingName = metadata.Uploader;
         }
         else
         {
             var jsonResult = GetParsedVideoJson(taggingSet);
 
-            workingName = jsonResult.IsFailed
-                ? string.Empty
-                : jsonResult.Value.Uploader.EndsWith(topicSuffix)
-                    ? jsonResult.Value.Uploader.Replace(topicSuffix, string.Empty)
-                    : jsonResult.Value.Uploader;
+            workingName = jsonResult.IsSuccess
+                ? jsonResult.Value.Uploader
+                : string.Empty;
         }
 
-        return workingName.ReplaceInvalidPathChars().Trim();
+        const string topicSuffix = " - Topic"; // Official channels append this to artist names.
+        var safeName = workingName.ReplaceInvalidPathChars().Trim();
+        return safeName.EndsWith(topicSuffix)
+            ? safeName.Replace(topicSuffix, string.Empty)
+            : safeName;
     }
 
     private static Result<VideoMetadata> GetParsedVideoJson(TaggingSet taggingSet)


### PR DESCRIPTION
Background:
- Videos' `Uploader` fields on official "Topic" channels' are suffixed with ` - Topic`
- This tool uses the uploader name as a subdirectory name, where ` - Topic` is undesirable

Update: Remove ` - Topic` from such subdirectory names.