### PR TITLE
Replace all (not just once) during file renaming

### DIFF
--- a/src/CCVTAC.Console/PostProcessing/Renamer.cs
+++ b/src/CCVTAC.Console/PostProcessing/Renamer.cs
@@ -15,37 +15,44 @@ internal static class Renamer
         Watch watch = new();
 
         var workingDirInfo = new DirectoryInfo(workingDirectory);
-        var audioFilePaths = workingDirInfo
+        var audioFiles = workingDirInfo
             .EnumerateFiles()
             .Where(f => PostProcessor.AudioExtensions.CaseInsensitiveContains(f.Extension))
             .ToImmutableList();
 
-        if (audioFilePaths.None())
+        if (audioFiles.None())
         {
             printer.Warning("No audio files to rename were found.");
             return;
         }
 
-        printer.Debug($"Renaming {audioFilePaths.Count} audio file(s)...");
+        printer.Debug($"Renaming {audioFiles.Count} audio file(s)...");
 
         string newFileName;
         Regex regex;
-        Match match;
+        MatchCollection allMatches;
+        List<Match> successMatches;
         string matchedPatternSummary;
 
-        foreach (FileInfo filePath in audioFilePaths)
+        foreach (FileInfo file in audioFiles)
         {
             newFileName =
                 settings.RenamePatterns.Aggregate(
-                    new StringBuilder(filePath.Name), // Seed is the original filename
+                    new StringBuilder(file.Name), // Seed
                     (newNameSb, renamePattern) =>
                     {
                         regex = new Regex(renamePattern.RegexPattern);
-                        match = regex.Match(newNameSb.ToString());
 
-                        if (!match.Success)
+                        // There will be multiple matches if the multiple instances are found.
+                        allMatches = regex.Matches(newNameSb.ToString());
+
+                        // Reverse to ensure processing starts at the end of the string
+                        // (to avoid indexing errors).
+                        successMatches = allMatches.Where(m => m.Success).Reverse().ToList();
+
+                        if (successMatches.Count == 0)
                         {
-                            return newNameSb; // Continue to the next iteration.
+                            return newNameSb;
                         }
 
                         if (!settings.QuietMode)
@@ -54,38 +61,41 @@ internal static class Renamer
                                 ? $"`{renamePattern.RegexPattern}` (no description)"
                                 : $"\"{renamePattern.Summary}\"";
 
-                            printer.Debug($"Rename pattern {matchedPatternSummary} matched.");
+                            printer.Debug($"Rename pattern {matchedPatternSummary} matched {successMatches.Count} time(s).");
                         }
 
-                        // Delete the matched substring from the filename by index.
-                        newNameSb.Remove(match.Index, match.Length);
+                        foreach (Match match in successMatches)
+                        {
+                            // Delete the matched substring from the filename by index.
+                            newNameSb.Remove(match.Index, match.Length);
 
-                        // Generate replacement text to be inserted at the same starting index
-                        // using the matches and the replacement patterns from the settings.
-                        // Match #1 correllates to placeholder #1.
-                        string insertText =
-                            match.Groups.OfType<Group>()
-                                // `Select()` indexing begins at 0, but usable matches begin at 1,
-                                // so add 1 to both the match group and replacement placeholder indices.
-                                .Select((gr, i) =>
-                                (
-                                    SearchFor:   $"%<{i + 1}>s", // Start with placeholder #1 because...
-                                    ReplaceWith: match.Groups[i + 1].Value.Trim() // ...we start with regex group #1.
-                                ))
-                                // Starting with the placeholder text from the settings, replace each
-                                // individual placeholder with the corrollated match text, then
-                                // return the final string.
-                                .Aggregate(
-                                    new StringBuilder(renamePattern.ReplaceWithPattern),
-                                    (workingText, replacementParts) =>
-                                        workingText.Replace(
-                                            replacementParts.SearchFor,
-                                            replacementParts.ReplaceWith),
-                                    workingText => workingText.ToString()
-                                );
+                            // Generate replacement text to be inserted at the same starting index
+                            // using the matches and the replacement patterns from the settings.
+                            // Match #1 correllates to placeholder #1.
+                            string insertText =
+                                match.Groups.OfType<Group>()
+                                    // `Select()` indexing begins at 0, but usable matches begin at 1,
+                                    // so add 1 to both the match group and replacement placeholder indices.
+                                    .Select((gr, i) =>
+                                    (
+                                        SearchFor:   $"%<{i + 1}>s", // Start with placeholder #1 because...
+                                        ReplaceWith: match.Groups[i + 1].Value.Trim() // ...we start with regex group #1.
+                                    ))
+                                    // Starting with the placeholder text from the settings, replace each
+                                    // individual placeholder with the corrollated match text, then
+                                    // return the final string.
+                                    .Aggregate(
+                                        new StringBuilder(renamePattern.ReplaceWithPattern), // Seed
+                                        (workingText, replacementParts) =>
+                                            workingText.Replace(
+                                                replacementParts.SearchFor,
+                                                replacementParts.ReplaceWith),
+                                        workingText => workingText.ToString()
+                                    );
 
-                        // Insert the final text at the same starting position.
-                        newNameSb.Insert(match.Index, insertText);
+                            // Insert the final text at the same starting position.
+                            newNameSb.Insert(match.Index, insertText);
+                        }
 
                         return newNameSb;
                     },
@@ -94,15 +104,15 @@ internal static class Renamer
             try
             {
                 File.Move(
-                    filePath.FullName,
+                    file.FullName,
                     Path.Combine(workingDirectory, newFileName));
 
-                printer.Debug($"• From: \"{filePath.Name}\"");
+                printer.Debug($"• From: \"{file.Name}\"");
                 printer.Debug($"    To: \"{newFileName}\"");
             }
             catch (Exception ex)
             {
-                printer.Error($"• Error renaming \"{filePath.Name}\": {ex.Message}");
+                printer.Error($"• Error renaming \"{file.Name}\": {ex.Message}");
             }
         }
 

--- a/src/CCVTAC.Console/PostProcessing/Renamer.cs
+++ b/src/CCVTAC.Console/PostProcessing/Renamer.cs
@@ -77,7 +77,7 @@ internal static class Renamer
                                     .Select((gr, i) =>
                                     (
                                         SearchFor:   $"%<{i + 1}>s", // Start with placeholder #1 because...
-                                        ReplaceWith: match.Groups[i + 1].Value // ...we start with regex group #1.
+                                        ReplaceWith: match.Groups[i + 1].Value.Trim() // ...we start with regex group #1.
                                     ))
                                     // Starting with the placeholder text from the settings, replace each
                                     // individual placeholder with the corrollated match text, then


### PR DESCRIPTION
I discovered that file rename replacements (using replacement patterns in the settings) where only finding the _first_ instance of target text in each filename. I've updated it to replace _all_ matches.

-----

Incidentally, discovered this by chance when I came across a video that used non-breaking spaces (` `, character code 160) in its name instead of regular spaces, which [AudioTagger](https://github.com/codeconscious/audiotagger) was unable to detect properly.

I added this to my settings under `renamePatterns` to resolve that for the future:

```json
    {
      "regex": " ",
      "replacePattern": " ",
      "summary": "Replace non-breaking spaces (char #160)"
    },
```