### PR TITLE
Improve handling of hidden videos

### DIFF
--- a/src/CCVTAC.Console/Downloading/Downloader.cs
+++ b/src/CCVTAC.Console/Downloading/Downloader.cs
@@ -47,7 +47,7 @@ internal static class Downloader
             string args = GenerateDownloadArgs(format, settings, mediaType, urls.Primary);
             var downloadSettings = new ToolSettings(ExternalTool, args, settings.WorkingDirectory!);
 
-            downloadResult = Runner.Run(downloadSettings, extraSuccessExitCodes: [1], printer);
+            downloadResult = Runner.Run(downloadSettings, otherSuccessExitCodes: [1], printer);
 
             if (downloadResult.IsSuccess)
             {
@@ -98,7 +98,7 @@ internal static class Downloader
             var supplementaryDownloadResult =
                 Runner.Run(
                     supplementaryDownloadSettings,
-                    extraSuccessExitCodes: [1],
+                    otherSuccessExitCodes: [1],
                     printer);
 
             if (supplementaryDownloadResult.IsSuccess)

--- a/src/CCVTAC.Console/Downloading/Downloader.cs
+++ b/src/CCVTAC.Console/Downloading/Downloader.cs
@@ -33,13 +33,13 @@ internal static class Downloader
 
         if (!mediaType.IsVideo && !mediaType.IsPlaylistVideo)
         {
-            printer.Info("Please wait for the multiple videos to be downloaded...");
+            printer.Info("Please wait for multiple videos to be downloaded...");
         }
 
         var rawUrls = FSharp.Downloading.ExtractDownloadUrls(mediaType);
         var urls = new Urls(rawUrls[0], rawUrls.Length == 2 ? rawUrls[1] : null);
 
-        Result<(int, string)> downloadResult = new();
+        var downloadResult = new Result<(int, string)> ();
         string? successfulFormat = null;
 
         foreach (string format in settings.AudioFormats)
@@ -47,16 +47,16 @@ internal static class Downloader
             string args = GenerateDownloadArgs(format, settings, mediaType, urls.Primary);
             var downloadSettings = new ToolSettings(ExternalTool, args, settings.WorkingDirectory!);
 
-            downloadResult = Runner.Run(downloadSettings, allowSuccessExitCodes: [1], printer);
+            downloadResult = Runner.Run(downloadSettings, extraSuccessExitCodes: [1], printer);
 
             if (downloadResult.IsSuccess)
             {
                 successfulFormat = format;
-                var (exitCode, warnings) = downloadResult.Value;
 
+                var (exitCode, warnings) = downloadResult.Value;
                 if (exitCode != 0)
                 {
-                    printer.Warning($"Downloading completed, but there were minor issues.");
+                    printer.Warning($"Downloading completed with minor issues.");
                     if (warnings.HasText())
                     {
                         printer.Warning(warnings);
@@ -98,7 +98,7 @@ internal static class Downloader
             var supplementaryDownloadResult =
                 Runner.Run(
                     supplementaryDownloadSettings,
-                    allowSuccessExitCodes: [1],
+                    extraSuccessExitCodes: [1],
                     printer);
 
             if (supplementaryDownloadResult.IsSuccess)

--- a/src/CCVTAC.Console/ExtensionMethods.cs
+++ b/src/CCVTAC.Console/ExtensionMethods.cs
@@ -66,4 +66,8 @@ public static class ExtensionMethods
         );
     }
 
+    public static string TrimTerminalLineBreak(this string text) =>
+        text.HasText()
+            ? text.TrimEnd(Environment.NewLine.ToCharArray())
+            : text;
 }

--- a/src/CCVTAC.Console/ExternalTools/Runner.cs
+++ b/src/CCVTAC.Console/ExternalTools/Runner.cs
@@ -42,7 +42,7 @@ internal static class Runner
         printer.Info($"Completed {settings.Program.Purpose} in {watch.ElapsedFriendly}.");
 
         return extraSuccessExitCodes.Append(0).Contains(process.ExitCode)
-            ? Result.Ok((process.ExitCode, errors.TrimEnd(Environment.NewLine.ToCharArray())))
-            : Result.Fail($"[{settings.Program.Name}] Exit code {process.ExitCode}. {errors.TrimEnd(Environment.NewLine.ToCharArray())}.");
+            ? Result.Ok((process.ExitCode, errors.TrimTerminalLineBreak()))
+            : Result.Fail($"[{settings.Program.Name}] Exit code {process.ExitCode}. {errors.TrimTerminalLineBreak()}.");
     }
 }

--- a/src/CCVTAC.Console/ExternalTools/Runner.cs
+++ b/src/CCVTAC.Console/ExternalTools/Runner.cs
@@ -50,7 +50,7 @@ internal static class Runner
 
         var trimmedErrors = errors.TrimTerminalLineBreak();
         return IsSuccessExitCode(otherSuccessExitCodes ?? [], process.ExitCode)
-            ? Result.Ok((process.ExitCode, trimmedErrors))
+            ? Result.Ok((process.ExitCode, trimmedErrors)) // Errors will be considered warnings.
             : Result.Fail($"[{settings.Program.Name}] Exit code {process.ExitCode}: {trimmedErrors}.");
     }
 }

--- a/src/CCVTAC.Console/ExternalTools/Runner.cs
+++ b/src/CCVTAC.Console/ExternalTools/Runner.cs
@@ -8,10 +8,10 @@ internal static class Runner
     /// Calls an external application.
     /// </summary>
     /// <param name="settings"></param>
-    /// <param name="allowSuccessExitCodes">Additional exit codes, other than 0, that can be treated as non-failures.</param>
+    /// <param name="extraSuccessExitCodes">Additional exit codes, other than 0, that can be treated as non-failures.</param>
     /// <param name="printer"></param>
     /// <returns>A `Result` containing the exit code, if successful, or else an error message.</returns>
-    internal static Result<(int ExitCode, string Warnings)> Run(ToolSettings settings, HashSet<int> allowSuccessExitCodes, Printer printer)
+    internal static Result<(int ExitCode, string Warnings)> Run(ToolSettings settings, HashSet<int> extraSuccessExitCodes, Printer printer)
     {
         Watch watch = new();
 
@@ -41,7 +41,7 @@ internal static class Runner
 
         printer.Info($"Completed {settings.Program.Purpose} in {watch.ElapsedFriendly}.");
 
-        return allowSuccessExitCodes.Append(0).Contains(process.ExitCode)
+        return extraSuccessExitCodes.Append(0).Contains(process.ExitCode)
             ? Result.Ok((process.ExitCode, errors.TrimEnd(Environment.NewLine.ToCharArray())))
             : Result.Fail($"[{settings.Program.Name}] Exit code {process.ExitCode}. {errors.TrimEnd(Environment.NewLine.ToCharArray())}.");
     }

--- a/src/CCVTAC.Console/ExternalTools/Runner.cs
+++ b/src/CCVTAC.Console/ExternalTools/Runner.cs
@@ -11,7 +11,10 @@ internal static class Runner
     /// <param name="extraSuccessExitCodes">Additional exit codes, other than 0, that can be treated as non-failures.</param>
     /// <param name="printer"></param>
     /// <returns>A `Result` containing the exit code, if successful, or else an error message.</returns>
-    internal static Result<(int ExitCode, string Warnings)> Run(ToolSettings settings, HashSet<int> extraSuccessExitCodes, Printer printer)
+    internal static Result<(int ExitCode, string Warnings)> Run(
+        ToolSettings settings,
+        HashSet<int> extraSuccessExitCodes,
+        Printer printer)
     {
         Watch watch = new();
 
@@ -41,8 +44,9 @@ internal static class Runner
 
         printer.Info($"Completed {settings.Program.Purpose} in {watch.ElapsedFriendly}.");
 
+        var trimmedErrors = errors.TrimTerminalLineBreak();
         return extraSuccessExitCodes.Append(0).Contains(process.ExitCode)
-            ? Result.Ok((process.ExitCode, errors.TrimTerminalLineBreak()))
-            : Result.Fail($"[{settings.Program.Name}] Exit code {process.ExitCode}. {errors.TrimTerminalLineBreak()}.");
+            ? Result.Ok((process.ExitCode, trimmedErrors))
+            : Result.Fail($"[{settings.Program.Name}] Exit code {process.ExitCode}: {trimmedErrors}.");
     }
 }

--- a/src/CCVTAC.Console/IoUtilties/Directories.cs
+++ b/src/CCVTAC.Console/IoUtilties/Directories.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Text;
+using CCVTAC.Console.PostProcessing;
 
 namespace CCVTAC.Console.IoUtilties;
 
@@ -7,6 +8,13 @@ internal static class Directories
 {
     private static readonly string AllFilesSearchPattern = "*";
     private static readonly EnumerationOptions EnumerationOptions = new();
+
+    internal static int AudioFileCount(string directory)
+    {
+        return new DirectoryInfo(directory)
+            .EnumerateFiles()
+            .Count(f => PostProcessor.AudioExtensions.CaseInsensitiveContains(f.Extension));
+    }
 
     internal static Result WarnIfAnyFiles(string directory, int showMax)
     {

--- a/src/CCVTAC.Console/PostProcessing/ImageProcessor.cs
+++ b/src/CCVTAC.Console/PostProcessing/ImageProcessor.cs
@@ -18,6 +18,6 @@ internal static class ImageProcessor
             workingDirectory
         );
 
-        Runner.Run(imageEditToolSettings, printer);
+        Runner.Run(imageEditToolSettings, [], printer);
     }
 }


### PR DESCRIPTION
I found that when playlists contained any hidden videos, the entire download would inappropriately be marked as unsuccessful even if other files were downloaded successfully. In this case, yt-dlp returns an exit code of `1`.

To avoid this, this PR allows treating `1` as a successful (non-error) exit code. The application will also show any errors from yt-dlp as just warnings in this case.