### PR TITLE
Check for and remove leftover temporary files

### DIFF
--- a/src/CCVTAC.Console/IoUtilities/Directories.cs
+++ b/src/CCVTAC.Console/IoUtilities/Directories.cs
@@ -27,7 +27,7 @@ internal static class Directories
         }
 
         var fileLabel = fileCount == 1 ? "file" : "files";
-        var report = new StringBuilder($"Found {fileCount} {fileLabel} in working directory \"{directory}\":{Environment.NewLine}");
+        var report = new StringBuilder($"Unexpectedly found {fileCount} {fileLabel} in working directory \"{directory}\":{Environment.NewLine}");
 
         foreach (string fileName in fileNames.Take(showMax))
         {
@@ -42,7 +42,7 @@ internal static class Directories
         return Result.Fail(report.ToString());
     }
 
-    private static Result<int> DeleteAllFiles(string workingDirectory, int showMaxErrors)
+    internal static Result<int> DeleteAllFiles(string workingDirectory, int showMaxErrors)
     {
         var fileNames = GetDirectoryFileNames(workingDirectory);
 

--- a/src/CCVTAC.Console/PostProcessing/Deleter.cs
+++ b/src/CCVTAC.Console/PostProcessing/Deleter.cs
@@ -25,9 +25,9 @@ internal static class Deleter
             printer.Warning(getFileResult.Errors.First().Message);
         }
 
-        var allFileNames = taggingSetFileNames.Concat(collectionFileNames).ToImmutableList();
+        var allFileNames = taggingSetFileNames.Concat(collectionFileNames).ToList();
 
-        if (allFileNames.IsEmpty)
+        if (allFileNames.Count == 0)
         {
             printer.Warning("No files to delete were found.");
             return;

--- a/src/CCVTAC.Console/PostProcessing/Mover.cs
+++ b/src/CCVTAC.Console/PostProcessing/Mover.cs
@@ -54,7 +54,7 @@ internal static class Mover
             workingDirInfo,
             fullMoveToDir,
             audioFileNames.Count,
-            overwrite: false,
+            overwrite,
             printer);
 
         var fileLabel = successCount == 1 ? "file" : "files";
@@ -168,7 +168,7 @@ internal static class Mover
             {
                 return;
             }
-            
+
             image.MoveTo(
                 Path.Combine(moveToDir, $"{baseFileName.Trim()}.jpg"),
                 overwrite: overwrite);

--- a/src/CCVTAC.Console/PostProcessing/PostProcessing.cs
+++ b/src/CCVTAC.Console/PostProcessing/PostProcessing.cs
@@ -1,10 +1,10 @@
 using System.IO;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using CCVTAC.Console.IoUtilities;
 using CCVTAC.Console.PostProcessing.Tagging;
 using UserSettings = CCVTAC.FSharp.Settings.UserSettings;
 using static CCVTAC.FSharp.Downloading;
-using CCVTAC.Console.IoUtilities;
 
 namespace CCVTAC.Console.PostProcessing;
 
@@ -58,10 +58,10 @@ internal static partial class PostProcessor
             var taggingSetFileNames = taggingSets.SelectMany(set => set.AllFiles).ToList();
             Deleter.Run(taggingSetFileNames, collectionJson, workingDirectory, printer);
 
-            var remainingFilesResult = Directories.WarnIfAnyFiles(workingDirectory, 10);
-            if (remainingFilesResult.IsFailed)
+            var leftoverFilesResult = Directories.WarnIfAnyFiles(workingDirectory, 20);
+            if (leftoverFilesResult.IsFailed)
             {
-                printer.FirstError(remainingFilesResult);
+                printer.FirstError(leftoverFilesResult);
 
                 printer.Info("Will delete the remaining files...");
                 var deleteResult = Directories.DeleteAllFiles(workingDirectory, 20);


### PR DESCRIPTION
A playlist containing the same video more than once leads to temporary files leftover after deletion. This PR ensures that any such temporary files are also deleted.